### PR TITLE
Feature/lobby error

### DIFF
--- a/src/LobbyClient.hs
+++ b/src/LobbyClient.hs
@@ -48,4 +48,5 @@ listenForLobbyChanges api = do
       updatePlayerList api
       updatePlayerListGame api
     PlayerJoinedGame -> updatePlayerListGame api
+    (LobbyError msg) -> liftIO $ print msg -- Update with some way to show error to client
   listenForLobbyChanges api

--- a/src/LobbyTypes.hs
+++ b/src/LobbyTypes.hs
@@ -90,7 +90,8 @@ lookupClientEntry :: SessionID -> [ClientEntry] -> Maybe ClientEntry
 lookupClientEntry sid = find ((sid ==) . sessionID)
 
 -- |LobbyMessage is a message to a client idicating some udate to the state that the cliet has to adapt to.
-data LobbyMessage = NickChange | GameNameChange | KickedFromGame | GameAdded | ClientJoined | ClientLeft | PlayerJoinedGame
+data LobbyMessage = NickChange | GameNameChange | KickedFromGame | GameAdded | ClientJoined
+      | ClientLeft | PlayerJoinedGame | LobbyError {lobbyErrorMessage :: String}
   deriving (Eq)
 
 instance Binary LobbyMessage where
@@ -101,6 +102,9 @@ instance Binary LobbyMessage where
   put ClientJoined     = put (4 :: Word8)
   put ClientLeft       = put (5 :: Word8)
   put PlayerJoinedGame = put (6 :: Word8)
+  put (LobbyError msg) = do
+    put (7 :: Word8)
+    put msg
 
   get = do
     tag <- get :: Get Word8
@@ -112,6 +116,9 @@ instance Binary LobbyMessage where
       4 -> return ClientJoined
       5 -> return ClientLeft
       6 -> return PlayerJoinedGame
+      7 -> do
+        msg <- get :: Get String
+        return $ LobbyError msg
 
 instance Binary Bool where
   put True  = put (0 :: Word8)


### PR DESCRIPTION
Simply adds a LobbyError data constructor to LobbyMessage. It can be used to notify the a client that an error has occurred, or that it was unable to join a game etc. fixes #57  
