### PR TITLE
Feature/show errors client

### DIFF
--- a/src/Views/Common.hs
+++ b/src/Views/Common.hs
@@ -91,3 +91,17 @@ addChildrenToParent parent children = do
 
 addChildrenToParent' :: Elem -> [Elem] -> Client ()
 addChildrenToParent' parent children = mapM_ (appendChild parent) children
+
+-- |Fades out an element (can not be a text element)
+fadeOutElem :: Elem -> Client ()
+fadeOutElem e = fadeOutElem' 1
+  where
+    fadeOutElem' :: Float -> Client ()
+    fadeOutElem' op | op <= 0.1 = do
+      setStyle e "display" "none"
+      return ()
+                    | otherwise = do
+      setStyle e "opacity" $ show op
+      setStyle e "filter" $ "alpha(opacity=" ++ show (op * 100) ++ ")"
+      setTimer (Once 10) $ fadeOutElem' (op - op * 0.1)
+      return ()

--- a/src/Views/Common.hs
+++ b/src/Views/Common.hs
@@ -92,6 +92,18 @@ addChildrenToParent parent children = do
 addChildrenToParent' :: Elem -> [Elem] -> Client ()
 addChildrenToParent' parent children = mapM_ (appendChild parent) children
 
+-- |Displays the error message in 'String'. Fades in the message and then out.
+showError :: String -> Client ()
+showError string = do
+  stringDiv <- newElem "h3" `with`
+    [
+      style "text-align" =: "center",
+      style "color"      =: "red"
+    ]
+  stringElem <- newTextElem string
+  addChildrenToParent' stringDiv [stringElem]
+  addChildrenToCenterColumn [stringDiv]
+  fadeInOutElem stringDiv
 
 -- |Fades in and then out a message after displaying it for 5 seconds
 fadeInOutElem :: Elem -> Client ()

--- a/src/Views/Common.hs
+++ b/src/Views/Common.hs
@@ -90,7 +90,7 @@ addChildrenToParent parent children = do
   addChildrenToParent' (fromJust parentElem) children
 
 addChildrenToParent' :: Elem -> [Elem] -> Client ()
-addChildrenToParent' parent children = mapM_ (appendChild parent) children
+addChildrenToParent' parent = mapM_ (appendChild parent)
 
 -- |Displays the error message in 'String'. Fades in the message and then out.
 showError :: String -> Client ()

--- a/src/Views/Common.hs
+++ b/src/Views/Common.hs
@@ -92,6 +92,21 @@ addChildrenToParent parent children = do
 addChildrenToParent' :: Elem -> [Elem] -> Client ()
 addChildrenToParent' parent children = mapM_ (appendChild parent) children
 
+
+-- |Fades in an element (can not be a text element)
+fadeInElem :: Elem -> Client ()
+fadeInElem e = do
+  setStyle e "display" "block"
+  fadeInElem' 0.1
+  where
+    fadeInElem' :: Float -> Client ()
+    fadeInElem' op | op > 1   = return ()
+                   | otherwise = do
+      setStyle e "opacity" $ show op
+      setStyle e "filter" $ "alpha(opacity=" ++ show (op * 100) ++ ")"
+      setTimer (Once 10) $ fadeInElem' (op + op * 0.1)
+      return ()
+
 -- |Fades out an element (can not be a text element)
 fadeOutElem :: Elem -> Client ()
 fadeOutElem e = fadeOutElem' 1

--- a/src/Views/Common.hs
+++ b/src/Views/Common.hs
@@ -93,6 +93,13 @@ addChildrenToParent' :: Elem -> [Elem] -> Client ()
 addChildrenToParent' parent children = mapM_ (appendChild parent) children
 
 
+-- |Fades in and then out a message after displaying it for 5 seconds
+fadeInOutElem :: Elem -> Client ()
+fadeInOutElem e = do
+  fadeInElem e
+  setTimer (Once 5000) $ fadeOutElem e
+  return ()
+
 -- |Fades in an element (can not be a text element)
 fadeInElem :: Elem -> Client ()
 fadeInElem e = do


### PR DESCRIPTION
Shows an error for 5 seconds and then fades it out. 

We need to find a good place to add the error though. Right now it is placed in the center column, furthest down. Maybe reserv a `<div>` at the top of the center column?

Fixes #35 
