### PR TITLE
Feature/chat

### DIFF
--- a/src/LobbyAPI.hs
+++ b/src/LobbyAPI.hs
@@ -47,7 +47,7 @@ data LobbyAPI = LobbyAPI
     -- |Reads next ChatMessage from named chat channel.
   , readChatChannel :: Remote (Name -> Server ChatMessage)
     -- |Get list of chats the client is in
-  , getChats :: Remote (Server [String])
+  , getJoinedChats :: Remote (Server [String])
   }
 
 -- |Creates an instance of the api used by the client to communicate with the server.
@@ -71,4 +71,4 @@ newLobbyAPI (playersList, gamesList, chatList) =
             <*> REMOTE((Server.leaveChat playersList))
             <*> REMOTE((Server.sendChatMessage playersList chatList))
             <*> REMOTE((Server.readChatChannel playersList))
-            <*> REMOTE((Server.getChats chatList))
+            <*> REMOTE((Server.getJoinedChats playersList))

--- a/src/LobbyAPI.hs
+++ b/src/LobbyAPI.hs
@@ -46,6 +46,8 @@ data LobbyAPI = LobbyAPI
   , sendChatMessage :: Remote (Name -> ChatMessage -> Server ())
     -- |Reads next ChatMessage from named chat channel.
   , readChatChannel :: Remote (Name -> Server ChatMessage)
+    -- |Get list of chats the client is in
+  , getChats :: Remote (Server [String])
   }
 
 -- |Creates an instance of the api used by the client to communicate with the server.
@@ -69,3 +71,4 @@ newLobbyAPI (playersList, gamesList, chatList) =
             <*> REMOTE((Server.leaveChat playersList))
             <*> REMOTE((Server.sendChatMessage playersList chatList))
             <*> REMOTE((Server.readChatChannel playersList))
+            <*> REMOTE((Server.getChats chatList))

--- a/src/LobbyAPI.hs
+++ b/src/LobbyAPI.hs
@@ -34,6 +34,8 @@ data LobbyAPI = LobbyAPI
   , getClientName :: Remote (Server String)
     -- |Join named chat
   , joinChat :: Remote (Name -> Server ())
+    -- |Leave named chat
+  , leaveChat :: Remote (Name -> Server ())
     -- |Send ChatMessage over Named channel
   , sendChatMessage :: Remote (Name -> ChatMessage -> Server ())
     -- |Reads next ChatMessage from named chat channel.
@@ -57,5 +59,6 @@ newLobbyAPI (playersList, gamesList, chatList) =
             <*> REMOTE((Server.readLobbyChannel playersList))
             <*> REMOTE((Server.getClientName playersList))
             <*> REMOTE((Server.joinChat playersList chatList))
+            <*> REMOTE((Server.leaveChat playersList))
             <*> REMOTE((Server.sendChatMessage playersList chatList))
             <*> REMOTE((Server.readChatChannel playersList))

--- a/src/LobbyAPI.hs
+++ b/src/LobbyAPI.hs
@@ -48,6 +48,8 @@ data LobbyAPI = LobbyAPI
   , readChatChannel :: Remote (Name -> Server ChatMessage)
     -- |Get list of chats the client is in
   , getJoinedChats :: Remote (Server [String])
+    -- |Get list of all chat names
+  , getChats :: Remote (Server [String])
   }
 
 -- |Creates an instance of the api used by the client to communicate with the server.
@@ -72,3 +74,4 @@ newLobbyAPI (playersList, gamesList, chatList) =
             <*> REMOTE((Server.sendChatMessage playersList chatList))
             <*> REMOTE((Server.readChatChannel playersList))
             <*> REMOTE((Server.getJoinedChats playersList))
+            <*> REMOTE((Server.getChats chatList))

--- a/src/LobbyClient.hs
+++ b/src/LobbyClient.hs
@@ -22,8 +22,9 @@ clientMain api = do
   createLobbyDOM api
 
   fork $ listenForLobbyChanges api
-  onServer $ joinChat api <.> "main"
-  fork $ listenForChatMessages api "main" chatMessageCallback
+
+  clientJoinChat api "main"
+
   return ()
 
 listenForLobbyChanges :: LobbyAPI -> Client ()

--- a/src/LobbyServer.hs
+++ b/src/LobbyServer.hs
@@ -240,7 +240,7 @@ notifyClientChats remoteClients notification = do
   clientList <- remoteClients >>= liftIO . CC.readMVar
   sid <- getSessionID
   liftIO . maybe
-    (print $ "notifyClientChats > Could not find sid in connected clients")
+    (print "notifyClientChats > Could not find sid in connected clients")
     (mapM_ (flip CC.writeChan (ChatMessage "SERVER" notification) . snd) . chats)
     $ sid `lookupClientEntry` clientList
 

--- a/src/LobbyServer.hs
+++ b/src/LobbyServer.hs
@@ -364,6 +364,8 @@ joinChat remoteClientList remoteChatList chatName = do
       addChatToClient chat client | chatName `elem` map fst (chats client) = client
                        | otherwise = client {chats = chat : chats client}
 
+-- | Sends a ChatAnnounceJoin to all clients present in the channel.
+-- | String is the name of the channel joined
 announceChatJoin :: Server ConcurrentClientList -> Server ConcurrentChatList -> String -> Server ()
 announceChatJoin remoteClientList remoteChatList chatName = do
   clientList <- remoteClientList >>= liftIO . CC.readMVar
@@ -377,6 +379,7 @@ announceChatJoin remoteClientList remoteChatList chatName = do
         Just client -> liftIO $ CC.writeChan channel $ ChatAnnounceJoin $ name client
 
 -- | Called by client to leave the named Chat
+-- | String is the name of the chat to be left
 leaveChat :: Server ConcurrentClientList -> String -> Server ()
 leaveChat remoteClientList chatName = do
   sid <- getSessionID
@@ -445,6 +448,7 @@ getClientName remoteClientList = do
   let client = find ((sid ==) . sessionID) clientList
   return $ name $ fromJust client
 
+-- | Return list of chatnames which the client have joined
 getJoinedChats :: Server ConcurrentClientList -> Server [String]
 getJoinedChats remoteClientList = do
   sid <- getSessionID

--- a/src/LobbyServer.hs
+++ b/src/LobbyServer.hs
@@ -58,6 +58,14 @@ connect remoteClientList remoteChats name = do
 -- |Disconnect client from server.
 disconnect :: LobbyState -> SessionID -> Server()
 disconnect (clientList, games, chats) sid = do
+  cs <- clientList >>= liftIO . CC.readMVar
+  maybe
+    (return ())
+    (\c -> do
+      notifyClientChats clientList $ (name c) ++ " disconnected"
+      return ())
+    $ sid `lookupClientEntry` cs
+
   disconnectPlayerFromGame games clientList sid
   disconnectPlayerFromLobby clientList sid
 

--- a/src/LobbyServer.hs
+++ b/src/LobbyServer.hs
@@ -245,18 +245,18 @@ changeNickName remoteClientList remoteGames newName = do
     clients <- CC.readMVar mVarClientList
     messageClients NickChange clients
   -- Notify all chats about nick update
-  notifyClientsJoinedChats remoteClientList $ oldName ++ " changed nick to " ++ newName
+  notifyClientChats remoteClientList $ oldName ++ " changed nick to " ++ newName
 
   where
     updateNick sid = updateListElem (\c -> c {name = newName}) (\c -> sid == sessionID c)
 
 -- | Sends a server notification to all chats the client has joined
-notifyClientsJoinedChats :: Server ConcurrentClientList -> String -> Server ()
-notifyClientsJoinedChats remoteClients notification = do
+notifyClientChats :: Server ConcurrentClientList -> String -> Server ()
+notifyClientChats remoteClients notification = do
   clientList <- remoteClients >>= liftIO . CC.readMVar
   sid <- getSessionID
   maybe
-    (liftIO . print $ "notifyClientsJoinedChats > Could not find sid in connected clients")
+    (liftIO . print $ "notifyClientChats > Could not find sid in connected clients")
     (liftIO . (mapM_ ((flip CC.writeChan $ ChatMessage "SERVER" notification) . snd)) . chats)
     $ sid `lookupClientEntry` clientList
 

--- a/src/LobbyServer.hs
+++ b/src/LobbyServer.hs
@@ -22,7 +22,8 @@ module LobbyServer(
   sendChatMessage,
   joinChat,
   leaveChat,
-  getClientName) where
+  getClientName,
+  getChats) where
 
 import Haste.App
 import qualified Control.Concurrent as CC
@@ -443,3 +444,8 @@ getClientName remoteClientList = do
   clientList <- liftIO $ CC.readMVar concurrentClientList
   let client = find ((sid ==) . sessionID) clientList
   return $ name $ fromJust client
+
+getChats :: Server ConcurrentChatList -> Server [String]
+getChats remoteChatList = do
+  chatList <- remoteChatList >>= liftIO . CC.readMVar
+  return $ map fst chatList

--- a/src/LobbyServer.hs
+++ b/src/LobbyServer.hs
@@ -374,9 +374,10 @@ announceChatJoin remoteClientList remoteChatList chatName = do
     Nothing      -> return ()
     Just channel -> do
       sid <- getSessionID
-      case sid `lookupClientEntry` clientList of
-        Nothing     -> return ()
-        Just client -> liftIO $ CC.writeChan channel $ ChatAnnounceJoin $ name client
+      maybe
+        (return ())
+        (liftIO . (CC.writeChan channel) . (ChatAnnounceJoin . name))
+        $ sid `lookupClientEntry` clientList
 
 -- | Called by client to leave the named Chat
 -- | String is the name of the chat to be left

--- a/src/LobbyServer.hs
+++ b/src/LobbyServer.hs
@@ -62,7 +62,7 @@ disconnect (clientList, games, chats) sid = do
   maybe
     (return ())
     (\c -> do
-      notifyClientChats clientList $ (name c) ++ " disconnected"
+      notifyClientChats clientList $ name c ++ " disconnected"
       return ())
     $ sid `lookupClientEntry` cs
 
@@ -265,7 +265,7 @@ notifyClientChats remoteClients notification = do
   sid <- getSessionID
   maybe
     (liftIO . print $ "notifyClientChats > Could not find sid in connected clients")
-    (liftIO . (mapM_ ((flip CC.writeChan $ ChatMessage "SERVER" notification) . snd)) . chats)
+    (liftIO . mapM_ (flip CC.writeChan (ChatMessage "SERVER" notification) . snd) . chats)
     $ sid `lookupClientEntry` clientList
 
 
@@ -405,7 +405,7 @@ announceChatJoin remoteClientList remoteChatList chatName = do
       sid <- getSessionID
       maybe
         (return ())
-        (liftIO . (CC.writeChan channel) . (ChatAnnounceJoin . name))
+        (liftIO . CC.writeChan channel . ChatAnnounceJoin . name)
         $ sid `lookupClientEntry` clientList
 
 -- | Called by client to leave the named Chat

--- a/src/LobbyServer.hs
+++ b/src/LobbyServer.hs
@@ -263,9 +263,9 @@ notifyClientChats :: Server ConcurrentClientList -> String -> Server ()
 notifyClientChats remoteClients notification = do
   clientList <- remoteClients >>= liftIO . CC.readMVar
   sid <- getSessionID
-  maybe
-    (liftIO . print $ "notifyClientChats > Could not find sid in connected clients")
-    (liftIO . mapM_ (flip CC.writeChan (ChatMessage "SERVER" notification) . snd) . chats)
+  liftIO . maybe
+    (print $ "notifyClientChats > Could not find sid in connected clients")
+    (mapM_ (flip CC.writeChan (ChatMessage "SERVER" notification) . snd) . chats)
     $ sid `lookupClientEntry` clientList
 
 

--- a/src/LobbyServer.hs
+++ b/src/LobbyServer.hs
@@ -23,7 +23,8 @@ module LobbyServer(
   joinChat,
   leaveChat,
   getClientName,
-  getJoinedChats) where
+  getJoinedChats,
+  getChats) where
 
 import Haste.App
 import qualified Control.Concurrent as CC
@@ -460,3 +461,9 @@ getJoinedChats remoteClientList = do
       return []
     Just client ->
       return $ map fst $ chats client
+
+-- | Return list of all chatnames
+getChats :: Server ConcurrentChatList -> Server [String]
+getChats remoteChatList = do
+  chatList <- remoteChatList >>= liftIO . CC.readMVar
+  return $ map fst chatList

--- a/src/LobbyServer.hs
+++ b/src/LobbyServer.hs
@@ -396,7 +396,7 @@ leaveChat remoteClientList chatName = do
             CC.writeChan channel $ ChatAnnounceLeave $ name client
             CC.modifyMVar_ concurrentClientList $ \clientList ->
               return $ updateListElem (\c -> c {chats =
-                deleteBy (\(cName1,_) (cName2,_) -> cName1 == cName2) (chatName, channel) $ chats client -- ((chatName ==).). fst) ??
+                deleteBy (\(cName1,_) (cName2,_) -> cName1 == cName2) (chatName, channel) $ chats client
                 }) ((sessionID client ==) . sessionID) clientList
           return ()
 

--- a/src/LobbyServer.hs
+++ b/src/LobbyServer.hs
@@ -357,7 +357,7 @@ joinChat remoteClientList remoteChatList chatName = do
         let chan = fromJust $ chatName `lookup` cs
         clientChan <- liftIO $ CC.dupChan chan
         let newChat = (chatName, clientChan)
-        liftIO $ CC.modifyMVar_ concurrentClientList $ \clients -> do
+        liftIO $ CC.modifyMVar_ concurrentClientList $ \clients ->
           return $ updateListElem (addChatToClient newChat) ((sid ==) . sessionID) clients
 
       addChatToClient :: Chat -> ClientEntry -> ClientEntry
@@ -384,8 +384,8 @@ leaveChat remoteClientList chatName = do
   cs <- liftIO $ CC.readMVar concurrentClientList
   case sid `lookupClientEntry` cs of
     Nothing     -> return ()
-    Just client -> do
-      case chatName `lookup` (chats client) of
+    Just client ->
+      case chatName `lookup` chats client of
         Nothing      -> return ()
         Just channel -> do
           liftIO $ do
@@ -406,8 +406,8 @@ readChatChannel remoteClientList chatName = do
   clients <- liftIO $ CC.readMVar concurrentClientList
   case sid `lookupClientEntry` clients of
     Nothing     -> return $ ChatError "Couldn't find clients sessionID in remotes client list, try reconnecting."
-    Just client -> do
-      case chatName `lookup` (chats client) of
+    Just client ->
+      case chatName `lookup` chats client of
         Nothing          -> return $ ChatError "Couldn't find chat in clients currently joined chats. join chat before trying to read from it"
         Just chatChannel -> liftIO $ CC.readChan chatChannel
 
@@ -422,7 +422,7 @@ sendChatMessage remoteClientList remoteChatList chatName chatMessage = do
 
   case chatName `lookup` chatList of
     Nothing   -> return ()
-    Just chatChannel -> do
+    Just chatChannel ->
       case sid `lookupClientEntry` clientList of
         Nothing     -> return()
         Just client -> do
@@ -451,7 +451,7 @@ getJoinedChats remoteClientList = do
   clientList <- remoteClientList >>= liftIO . CC.readMVar
   case sid `lookupClientEntry` clientList of
     Nothing     -> do
-      liftIO $ print $ "getJoinedChats > Error: expected client not found."
+      liftIO $ print "getJoinedChats > Error: expected client not found."
       return []
     Just client ->
       return $ map fst $ chats client

--- a/src/Views/Chat.hs
+++ b/src/Views/Chat.hs
@@ -209,7 +209,7 @@ setActiveChat chatName = do
 -- | Client joins the named chat and starts listen to it's messages
 clientJoinChat :: LobbyAPI -> String -> Client ()
 clientJoinChat api chatName = do
-  chats <- onServer $ getChats api
+  chats <- onServer $ getJoinedChats api
   if chatName `elem` chats
     then
       setActiveChat chatName

--- a/src/Views/Chat.hs
+++ b/src/Views/Chat.hs
@@ -219,6 +219,8 @@ clientJoinChat api chatName = do
       setActiveChat chatName
   return ()
 
+-- | Tells the server that the client wants to leave the named chat.
+-- | Special case. You can't leave the chat named "main".
 clientLeaveChat :: LobbyAPI -> String -> Client ()
 clientLeaveChat api chatName =
   if chatName == "main"

--- a/src/Views/Chat.hs
+++ b/src/Views/Chat.hs
@@ -103,6 +103,8 @@ addNewTabToTabsHeader chatName =
         attr "id"   =: ("chat-tab-" ++ chatName),
         attr "role" =: "presentation"
       ]
+    onEvent chatTab Click $ \_ -> setActiveChat chatName
+
     textElem <- newTextElem chatName
     appendChild chatTab textElem
     appendChild chatTabsHeader chatTab

--- a/src/Views/Chat.hs
+++ b/src/Views/Chat.hs
@@ -3,7 +3,6 @@ module Views.Chat
     listenForChatMessages,
     chatMessageCallback,
     createChatDOM,
-    addNewChat,
     clientJoinChat
     ) where
 

--- a/src/Views/Chat.hs
+++ b/src/Views/Chat.hs
@@ -283,7 +283,7 @@ pushToChatBox chatName str = (chatContainerIdPrefix ++ chatName) `withElem` \cha
   scrollToBottom chatContainer
   return ()
 
--- | Set set the scrollTop property equal to the scrollHeight property.
+-- | Set the scrollTop property equal to the scrollHeight property.
 scrollToBottom :: Elem -> Client()
 scrollToBottom scrollableElem = do
   scrollHeight <- getProp scrollableElem "scrollHeight"

--- a/src/Views/Chat.hs
+++ b/src/Views/Chat.hs
@@ -110,6 +110,7 @@ createChatTabsHeader =
     [
       attr "id" =: chatTabId,
       attr "class" =: "nav nav-tabs",
+      attr "style" =: "overflow-x: scroll; overflow-y: hidden; display: -webkit-box;",
       attr "role" =: "tablist"
     ]
 
@@ -127,8 +128,9 @@ addTabToTabHeader chatName =
   chatTabId `withElem` \chatTabsHeader -> do
     chatTab <- newElem "li" `with`
       [
-        attr "id"   =: (chatTabIdPrefix ++ chatName),
-        attr "role" =: "presentation"
+        attr "id"    =: (chatTabIdPrefix ++ chatName),
+        attr "role"  =: "presentation",
+        attr "style" =: "float: none;"
       ]
     onEvent chatTab Click $ \_ -> setActiveChat chatName
 

--- a/src/Views/Chat.hs
+++ b/src/Views/Chat.hs
@@ -95,19 +95,6 @@ addNewChat chatName = do
   addNewTabToTabsHeader chatName
   addNewChatToChatsContainer chatName
 
-setActiveChat :: String -> Client ()
-setActiveChat chatName = "chats-container" `withElem` \chatContainer -> do
-  children <- getChildren chatContainer
-  liftIO $ print $ length children
-  mapM_ (\c -> setAttr c "class" "hide") children
-  activeChat <- elemById $ "chat-container-" ++ chatName
-  case activeChat of
-    Nothing   -> return ()
-    Just chat -> do
-      setAttr chat "class" ""
-      scrollToBottom chat
-  return ()
-
 addNewTabToTabsHeader :: String -> Client ()
 addNewTabToTabsHeader chatName =
   "chat-tabs" `withElem` \chatTabsHeader -> do
@@ -129,6 +116,19 @@ addNewChatToChatsContainer chatName =
         attr "style" =: "overflow: auto; height: 200px"
       ]
     appendChild chatsContainer chatContainer
+
+setActiveChat :: String -> Client ()
+setActiveChat chatName = "chats-container" `withElem` \chatContainer -> do
+  children <- getChildren chatContainer
+  liftIO $ print $ length children
+  mapM_ (\c -> setAttr c "class" "hide") children
+  activeChat <- elemById $ "chat-container-" ++ chatName
+  case activeChat of
+    Nothing   -> return ()
+    Just chat -> do
+      setAttr chat "class" ""
+      scrollToBottom chat
+  return ()
 
 -- | Client joins the named chat and starts listen to it's messages
 clientJoinChat :: LobbyAPI -> String -> Client ()

--- a/src/Views/Chat.hs
+++ b/src/Views/Chat.hs
@@ -183,10 +183,15 @@ deleteChatDOM chatName = do
 -- | All other chat elements are hidden.
 setActiveChat :: String -> Client ()
 setActiveChat chatName = do
-  chatTabId `withElem` \chatTabs -> do
-    setClassOnChildren chatTabs "active" False
+  chatTabId `withElem` \chatTabContainer -> do
+    setClassOnChildren chatTabContainer "active" False
     maybeChatTab <- elemById $ chatTabIdPrefix ++ chatName
     setClassOnMaybeDOMElem maybeChatTab "active" True
+    maybe
+      (return ())
+      (scrollToElem chatTabContainer)
+      maybeChatTab
+
 
   chatContainerId `withElem` \chatContainer -> do
     setClassOnChildren chatContainer "hide" True
@@ -283,6 +288,12 @@ scrollToBottom :: Elem -> Client()
 scrollToBottom scrollableElem = do
   scrollHeight <- getProp scrollableElem "scrollHeight"
   setProp scrollableElem "scrollTop" scrollHeight
+
+-- | Set the parents scrollLeft property equal to the childs offsetLeft
+scrollToElemHorizontal :: Elem -> Elem -> Client()
+scrollToElem parent child = do
+  offsetLeft <- getProp child "offsetLeft"
+  setProp parent "scrollLeft" offsetLeft
 
 -- |Listen for chat messages on a chatChannel until the chat announces that the client leaves
 -- |Start this method with fork $ listenForChatMessage args...

--- a/src/Views/Chat.hs
+++ b/src/Views/Chat.hs
@@ -266,9 +266,6 @@ chatMessageCallback api chatName (ChatAnnounceJoin from)    =
   pushToChatBox chatName $ from ++ " has joined " ++ chatName
 chatMessageCallback api chatName (ChatAnnounceLeave from)   = do
   pushToChatBox chatName $ from ++ " has left " ++ chatName
-  --thisClientName <- onServer $ getClientName api
-  --when (from == thisClientName) $ deleteChatDOM chatName
-  --return ()
 chatMessageCallback api chatName (ChatError errorMessage)   = do
   liftIO . print $ "chatMessageCallback > " ++ "ChatError" ++ errorMessage
   pushToChatBox "main" $ "ChatError" ++ errorMessage

--- a/src/Views/Chat.hs
+++ b/src/Views/Chat.hs
@@ -181,7 +181,10 @@ setActiveChat chatName = do
   "input-container" `withElem` \inputs -> do
     setClassOnChildren inputs "hide"
     maybeInputField <- elemById $ "input-field-" ++ chatName
-    setClassOnMaybeDOMElem maybeInputField ""
+    setClassOnMaybeDOMElem maybeInputField "form-control"
+    if isJust maybeInputField
+      then focus $ fromJust maybeInputField
+      else return ()
   return ()
     where
       setClassOnChildren parent value = do

--- a/src/Views/Chat.hs
+++ b/src/Views/Chat.hs
@@ -80,10 +80,8 @@ handleChatInput api currentChatName =
         then
           pushToChatBox chatName "Missing chatname, use: /join [CHATNAME]"
         else let chatName' = head args in do
-          liftIO $ print $ "handleChatCommand > joining chat: " ++ chatName'
           clientJoinChat api chatName'
       | c == "leave"  = do
-        liftIO $ print $ "handleChatCommand > leaving chat: " ++ chatName
         if null args
           then do
             clientLeaveChat api chatName
@@ -98,7 +96,6 @@ handleChatInput api currentChatName =
         let chatName = head args
             chatMessage = unwords $ tail args
         in do
-        liftIO $ print $ "handleCatCommand > msg chat: " ++ chatName ++ ": " ++ chatMessage
         onServer $ sendChatMessage api <.> chatName <.> ChatMessage "" chatMessage
 
 -- |Add the header container for chat tabs
@@ -229,14 +226,11 @@ clientLeaveChat api chatName =
 
 -- | Called when a ChatMessage is received
 chatMessageCallback :: LobbyAPI -> String -> ChatMessage -> Client ()
-chatMessageCallback api chatName (ChatMessage from content) = do
-  liftIO $ print $ "chatMessageCallback > Chat:{" ++ chatName ++ "} from:{" ++ from ++ "] message:{" ++ content ++ "}"
+chatMessageCallback api chatName (ChatMessage from content) =
   pushToChatBox chatName $ from ++ ": " ++ content
-chatMessageCallback api chatName (ChatAnnounceJoin from)    = do
-  liftIO $ print $ "chatMessageCallback > " ++ from ++ " has joined"
+chatMessageCallback api chatName (ChatAnnounceJoin from)    =
   pushToChatBox chatName $ from ++ " has joined " ++ chatName
 chatMessageCallback api chatName (ChatAnnounceLeave from)   = do
-  liftIO $ print $ "chatMessageCallback > " ++ from ++ " has left"
   pushToChatBox chatName $ from ++ " has left " ++ chatName
   thisClientName <- onServer $ getClientName api
   if from == thisClientName

--- a/src/Views/Chat.hs
+++ b/src/Views/Chat.hs
@@ -123,7 +123,9 @@ addTabToTabHeader chatName =
     onEvent chatTab Click $ \_ -> setActiveChat chatName
 
     textElem <- newTextElem chatName
-    appendChild chatTab textElem
+    linkWrapper <- newElem "a"
+    appendChild linkWrapper textElem
+    appendChild chatTab linkWrapper
     appendChild chatTabsHeader chatTab
 
 -- | Adds a new chat window to the chat container.

--- a/src/Views/Chat.hs
+++ b/src/Views/Chat.hs
@@ -198,14 +198,14 @@ setActiveChat chatName = do
 -- | Client joins the named chat and starts listen to it's messages
 clientJoinChat :: LobbyAPI -> String -> Client ()
 clientJoinChat api chatName = do
-  maybeChatContainer <- elemById $ "chat-container-" ++ chatName
-  case maybeChatContainer of
-    Nothing -> do
+  chats <- onServer $ getChats api
+  if chatName `elem` chats
+    then
+      setActiveChat chatName
+    else do
       onServer $ joinChat api <.> chatName
       addNewChat api chatName
       fork $ listenForChatMessages api chatName $ chatMessageCallback chatName
-      setActiveChat chatName
-    Just _ ->
       setActiveChat chatName
   return ()
 

--- a/src/Views/Chat.hs
+++ b/src/Views/Chat.hs
@@ -182,16 +182,16 @@ clientJoinChat api chatName = do
 chatMessageCallback :: String -> ChatMessage -> Client ()
 chatMessageCallback chatName (ChatMessage from content) = do
   liftIO $ print $ "chatMessageCallback > Chat:{" ++ chatName ++ "} from:{" ++ from ++ "] message:{" ++ content ++ "}"
-  pushToChatBox chatName $from ++ ": " ++ content
+  pushToChatBox chatName $ from ++ ": " ++ content
 chatMessageCallback chatName (ChatAnnounceJoin from)    = do
   liftIO $ print $ "chatMessageCallback > " ++ from ++ " has joined"
-  pushToChatBox chatName $from ++ "has joined"
+  pushToChatBox chatName $ from ++ "has joined"
 chatMessageCallback chatName (ChatAnnounceLeave from)   = do
   liftIO $ print $ "chatMessageCallback > " ++ from ++ " has left"
-  pushToChatBox chatName $from ++ "has left"
+  pushToChatBox chatName $ from ++ "has left"
 chatMessageCallback chatName (ChatError errorMessage)   = do
   liftIO $ print $ "chatMessageCallback > " ++ "ChatError" ++ errorMessage
-  pushToChatBox chatName $"ChatError" ++ errorMessage
+  pushToChatBox chatName $ "ChatError" ++ errorMessage
 chatMessageCallback chatName _ =
   liftIO $ print $ "chatMessageCallback > Bad ChatMessage on chat " ++ chatName
 

--- a/src/Views/Chat.hs
+++ b/src/Views/Chat.hs
@@ -11,10 +11,11 @@ import Haste
 import Haste.Events
 import Haste.DOM
 import Haste.App.Concurrent
+import Data.Maybe
+import Control.Monad (unless)
+
 import LobbyTypes
 import LobbyAPI
-import Control.Monad (unless)
-import Data.Maybe
 import Views.Common
 
 -- | Create chat DOM in the left column

--- a/src/Views/Chat.hs
+++ b/src/Views/Chat.hs
@@ -180,29 +180,32 @@ deleteChatDOM chatName = do
 setActiveChat :: String -> Client ()
 setActiveChat chatName = do
   chatTabId `withElem` \chatTabs -> do
-    setClassOnChildren chatTabs ""
+    setClassOnChildren chatTabs "active" False
     maybeChatTab <- elemById $ chatTabIdPrefix ++ chatName
-    setClassOnMaybeDOMElem maybeChatTab "active"
+    setClassOnMaybeDOMElem maybeChatTab "active" True
+
   chatContainerId `withElem` \chatContainer -> do
-    setClassOnChildren chatContainer "hide"
+    setClassOnChildren chatContainer "hide" True
     maybeChatContainer <- elemById $ chatContainerIdPrefix ++ chatName
-    setClassOnMaybeDOMElem maybeChatContainer ""
+    setClassOnMaybeDOMElem maybeChatContainer "hide" False
+
   inputContainerId `withElem` \inputs -> do
-    setClassOnChildren inputs "hide"
+    setClassOnChildren inputs "hide" True
     maybeInputField <- elemById $ inputFieldIdPrefix ++ chatName
-    setClassOnMaybeDOMElem maybeInputField "form-control"
+    setClassOnMaybeDOMElem maybeInputField "hide" False
+
     maybe  (return ()) focus maybeInputField
   return ()
     where
-      setClassOnChildren parent value = do
+      setClassOnChildren parent value doSet = do
         children <- getChildren parent
-        mapM_ (\c -> setAttr c "class" value) children
+        mapM_ (\c -> setClass c value doSet) children
 
-      setClassOnMaybeDOMElem maybeDOMElem attr =
+      setClassOnMaybeDOMElem maybeDOMElem value doSet =
         case maybeDOMElem of
           Nothing   -> return ()
           Just chat -> do
-            setAttr chat "class" attr
+            setClass chat value doSet
             scrollToBottom chat
 
 -- | Client joins the named chat and starts listen to it's messages

--- a/src/Views/Chat.hs
+++ b/src/Views/Chat.hs
@@ -85,10 +85,15 @@ handleChatInput api currentChatName =
       | c == "leave"  = do
         liftIO $ print $ "handleChatCommand > leaving chat: " ++ chatName
         if null args
-          then
+          then do
             clientLeaveChat api chatName
-          else let chatName' = head args in
+            setActiveChat "main"
+          else do
+            let chatName' = head args
             clientLeaveChat api chatName'
+            if chatName == chatName'
+              then setActiveChat "main"
+              else return ()
       | c == "msg"  =
         let chatName = head args
             chatMessage = unwords $ tail args

--- a/src/Views/Chat.hs
+++ b/src/Views/Chat.hs
@@ -189,7 +189,7 @@ setActiveChat chatName = do
     maybe (return ())
       (\tab -> do
         setClass tab "active" True
-        scrollToElemHorizontal chatTabContainer tab
+        scrollToElemHorizontal chatTabContainer tab (-60)
       )
       maybeChatTab
 
@@ -292,10 +292,12 @@ scrollToBottom scrollableElem = do
   setProp scrollableElem "scrollTop" scrollHeight
 
 -- | Set the parents scrollLeft property equal to the childs offsetLeft
-scrollToElemHorizontal :: Elem -> Elem -> Client()
-scrollToElemHorizontal parent child = do
+-- | Int is offset to apply on scroll
+scrollToElemHorizontal :: Elem -> Elem -> Int -> Client()
+scrollToElemHorizontal parent child offset = do
   offsetLeft <- getProp child "offsetLeft"
-  setProp parent "scrollLeft" offsetLeft
+  width <- getProp child "width"
+  setProp parent "scrollLeft" . show $ read offsetLeft + offset
 
 -- |Listen for chat messages on a chatChannel until the chat announces that the client leaves
 -- |Start this method with fork $ listenForChatMessage args...

--- a/src/Views/Chat.hs
+++ b/src/Views/Chat.hs
@@ -185,10 +185,10 @@ chatMessageCallback chatName (ChatMessage from content) = do
   pushToChatBox chatName $ from ++ ": " ++ content
 chatMessageCallback chatName (ChatAnnounceJoin from)    = do
   liftIO $ print $ "chatMessageCallback > " ++ from ++ " has joined"
-  pushToChatBox chatName $ from ++ "has joined"
+  pushToChatBox chatName $ from ++ " has joined " ++ chatName
 chatMessageCallback chatName (ChatAnnounceLeave from)   = do
   liftIO $ print $ "chatMessageCallback > " ++ from ++ " has left"
-  pushToChatBox chatName $ from ++ "has left"
+  pushToChatBox chatName $ from ++ " has left " ++ chatName
 chatMessageCallback chatName (ChatError errorMessage)   = do
   liftIO $ print $ "chatMessageCallback > " ++ "ChatError" ++ errorMessage
   pushToChatBox chatName $ "ChatError" ++ errorMessage

--- a/src/Views/Chat.hs
+++ b/src/Views/Chat.hs
@@ -171,9 +171,9 @@ addInputFieldToInputFieldsContainer api chatName =
 -- | Removes the DOM elements corresponding to the named chat
 deleteChatDOM :: String -> Client ()
 deleteChatDOM chatName = do
-  liftIO $ print $ chatTabIdPrefix       ++ chatName
-  liftIO $ print $ chatContainerIdPrefix ++ chatName
-  liftIO $ print $ inputFieldIdPrefix    ++ chatName
+  liftIO . print $ chatTabIdPrefix       ++ chatName
+  liftIO . print $ chatContainerIdPrefix ++ chatName
+  liftIO . print $ inputFieldIdPrefix    ++ chatName
   deleteDOM (chatTabIdPrefix       ++ chatName) chatTabId
   deleteDOM (chatContainerIdPrefix ++ chatName) chatContainerId
   deleteDOM (inputFieldIdPrefix    ++ chatName) inputContainerId
@@ -229,7 +229,7 @@ clientJoinChat api chatName = do
       let chatToJoin = fromMaybe chatName $ find ((lowerCaseChatName ==). stringToLower) chats
       onServer $ joinChat api <.> chatToJoin
       addNewChatDOM api chatToJoin
-      fork $ listenForChatMessages api chatToJoin $ chatMessageCallback api chatToJoin
+      fork . listenForChatMessages api chatToJoin $ chatMessageCallback api chatToJoin
       setActiveChat chatToJoin
   return ()
   where
@@ -268,10 +268,10 @@ chatMessageCallback api chatName (ChatAnnounceLeave from)   = do
   --when (from == thisClientName) $ deleteChatDOM chatName
   --return ()
 chatMessageCallback api chatName (ChatError errorMessage)   = do
-  liftIO $ print $ "chatMessageCallback > " ++ "ChatError" ++ errorMessage
+  liftIO . print $ "chatMessageCallback > " ++ "ChatError" ++ errorMessage
   pushToChatBox "main" $ "ChatError" ++ errorMessage
 chatMessageCallback api chatName _ =
-  liftIO $ print $ "chatMessageCallback > Bad ChatMessage on chat " ++ chatName
+  liftIO . print $ "chatMessageCallback > Bad ChatMessage on chat " ++ chatName
 
 -- |Pushes the String arguments to the "chatBox" textarea
 pushToChatBox :: String -> String -> Client ()

--- a/src/Views/Chat.hs
+++ b/src/Views/Chat.hs
@@ -207,9 +207,7 @@ setActiveChat chatName = do
     setClassOnChildren inputs "hide" True
     maybeInputField <- elemById $ inputFieldIdPrefix ++ chatName
     maybe (return ())
-      (\inputField -> do
-        setClass inputField "hide" False
-      )
+      (\inputField -> setClass inputField "hide" False)
       maybeInputField
 
     maybe  (return ()) focus maybeInputField
@@ -223,7 +221,7 @@ setActiveChat chatName = do
 clientJoinChat :: LobbyAPI -> String -> Client ()
 clientJoinChat api chatName = do
   joinedChats <- onServer $ getJoinedChats api
-  if lowerCaseChatName `elem` (map stringToLower joinedChats)
+  if lowerCaseChatName `elem` map stringToLower joinedChats
     then
       setActiveChat chatName
     else do
@@ -264,7 +262,7 @@ chatMessageCallback api chatName (ChatMessage from content) =
   pushToChatBox chatName $ from ++ ": " ++ content
 chatMessageCallback api chatName (ChatAnnounceJoin from)    =
   pushToChatBox chatName $ from ++ " has joined " ++ chatName
-chatMessageCallback api chatName (ChatAnnounceLeave from)   = do
+chatMessageCallback api chatName (ChatAnnounceLeave from)   =
   pushToChatBox chatName $ from ++ " has left " ++ chatName
 chatMessageCallback api chatName (ChatError errorMessage)   = do
   liftIO . print $ "chatMessageCallback > " ++ "ChatError" ++ errorMessage

--- a/src/Views/Chat.hs
+++ b/src/Views/Chat.hs
@@ -92,11 +92,11 @@ createChatDOM api parentDiv = do
 
 addNewChat :: String -> Client ()
 addNewChat chatName = do
-  addNewTabTotabsHeader chatName
+  addNewTabToTabsHeader chatName
   addNewChatToChatsContainer chatName
 
-addNewTabTotabsHeader :: String -> Client ()
-addNewTabTotabsHeader chatName =
+addNewTabToTabsHeader :: String -> Client ()
+addNewTabToTabsHeader chatName =
   "chat-tabs" `withElem` \chatTabsHeader -> do
     chatTab <- newElem "li" `with`
       [

--- a/src/Views/Chat.hs
+++ b/src/Views/Chat.hs
@@ -76,9 +76,12 @@ handleChatInput api currentChatName =
   where
     handleChatCommand :: String -> [String] -> String -> Client ()
     handleChatCommand c args chatName
-      | c == "join"  = let chatName' = head args in do
-        liftIO $ print $ "handleChatCommand > joining chat: " ++ chatName'
-        clientJoinChat api chatName'
+      | c == "join"  = if null args
+        then
+          pushToChatBox chatName "Missing chatname, use: /join [CHATNAME]"
+        else let chatName' = head args in do
+          liftIO $ print $ "handleChatCommand > joining chat: " ++ chatName'
+          clientJoinChat api chatName'
       | c == "leave"  = do
         liftIO $ print $ "handleChatCommand > leaving chat: " ++ chatName
         if null args

--- a/src/Views/Chat.hs
+++ b/src/Views/Chat.hs
@@ -148,7 +148,7 @@ clientJoinChat api chatName = do
 -- | Called when a ChatMessage is received
 chatMessageCallback :: String -> ChatMessage -> Client ()
 chatMessageCallback chatName (ChatMessage from content) = do
-  liftIO $ print $ "chatMessageCallback > " ++ from ++ ": " ++ content
+  liftIO $ print $ "chatMessageCallback > Chat:{" ++ chatName ++ "} from:{" ++ from ++ "] message:{" ++ content ++ "}"
   pushToChatBox $ from ++ ": " ++ content
 chatMessageCallback chatName (ChatAnnounceJoin from)    = do
   liftIO $ print $ "chatMessageCallback > " ++ from ++ " has joined"

--- a/src/Views/Chat.hs
+++ b/src/Views/Chat.hs
@@ -186,22 +186,31 @@ setActiveChat chatName = do
   chatTabId `withElem` \chatTabContainer -> do
     setClassOnChildren chatTabContainer "active" False
     maybeChatTab <- elemById $ chatTabIdPrefix ++ chatName
-    setClassOnMaybeDOMElem maybeChatTab "active" True
-    maybe
-      (return ())
-      (scrollToElem chatTabContainer)
+    maybe (return ())
+      (\tab -> do
+        setClass tab "active" True
+        scrollToElemHorizontal chatTabContainer tab
+      )
       maybeChatTab
-
 
   chatContainerId `withElem` \chatContainer -> do
     setClassOnChildren chatContainer "hide" True
     maybeChatContainer <- elemById $ chatContainerIdPrefix ++ chatName
-    setClassOnMaybeDOMElem maybeChatContainer "hide" False
+    maybe (return ())
+      (\chat -> do
+        setClass chat "hide" False
+        scrollToBottom chat
+      )
+      maybeChatContainer
 
   inputContainerId `withElem` \inputs -> do
     setClassOnChildren inputs "hide" True
     maybeInputField <- elemById $ inputFieldIdPrefix ++ chatName
-    setClassOnMaybeDOMElem maybeInputField "hide" False
+    maybe (return ())
+      (\inputField -> do
+        setClass inputField "hide" False
+      )
+      maybeInputField
 
     maybe  (return ()) focus maybeInputField
   return ()
@@ -209,13 +218,6 @@ setActiveChat chatName = do
       setClassOnChildren parent value doSet = do
         children <- getChildren parent
         mapM_ (\c -> setClass c value doSet) children
-
-      setClassOnMaybeDOMElem maybeDOMElem value doSet =
-        case maybeDOMElem of
-          Nothing   -> return ()
-          Just chat -> do
-            setClass chat value doSet
-            scrollToBottom chat
 
 -- | Client joins the named chat and starts listen to it's messages
 clientJoinChat :: LobbyAPI -> String -> Client ()
@@ -291,7 +293,7 @@ scrollToBottom scrollableElem = do
 
 -- | Set the parents scrollLeft property equal to the childs offsetLeft
 scrollToElemHorizontal :: Elem -> Elem -> Client()
-scrollToElem parent child = do
+scrollToElemHorizontal parent child = do
   offsetLeft <- getProp child "offsetLeft"
   setProp parent "scrollLeft" offsetLeft
 

--- a/src/Views/Chat.hs
+++ b/src/Views/Chat.hs
@@ -118,7 +118,7 @@ addChatToChatsContainer chatName =
     chatContainer <- newElem "div" `with`
       [
         attr "id" =: ("chat-container-" ++ chatName),
-        attr "style" =: "overflow: auto; height: 200px"
+        attr "style" =: "overflow: auto; height: 200px; word-wrap: break-word;"
       ]
     appendChild chatsContainer chatContainer
 

--- a/src/Views/Chat.hs
+++ b/src/Views/Chat.hs
@@ -90,12 +90,14 @@ createChatTabsHeader = do
 
 addNewChat :: LobbyAPI -> String -> Client ()
 addNewChat api chatName = do
-  addNewTabToTabsHeader chatName
-  addNewChatToChatsContainer chatName
+  addTabToTabsHeader chatName
+  addChatToChatsContainer chatName
   addInputFieldToInputsContainer api chatName
 
-addNewTabToTabsHeader :: String -> Client ()
-addNewTabToTabsHeader chatName =
+-- | Adds a new named tab to the tabs header.
+-- | Clicks on this tabs changes changes to only show its respective chat window and input field
+addTabToTabsHeader :: String -> Client ()
+addTabToTabsHeader chatName =
   "chat-tabs" `withElem` \chatTabsHeader -> do
     chatTab <- newElem "li" `with`
       [
@@ -108,8 +110,10 @@ addNewTabToTabsHeader chatName =
     appendChild chatTab textElem
     appendChild chatTabsHeader chatTab
 
-addNewChatToChatsContainer :: String -> Client ()
-addNewChatToChatsContainer chatName =
+-- | Adds a new chat window to the chat container.
+-- | The given string is used to set an id attribute.
+addChatToChatsContainer :: String -> Client ()
+addChatToChatsContainer chatName =
   "chats-container" `withElem` \chatsContainer -> do
     chatContainer <- newElem "div" `with`
       [
@@ -118,6 +122,8 @@ addNewChatToChatsContainer chatName =
       ]
     appendChild chatsContainer chatContainer
 
+-- | Adds a new input field to the inputs container.
+-- | The input field forwards the message to the handleChatInput function when 'enter' is pressed.
 addInputFieldToInputsContainer :: LobbyAPI -> String -> Client ()
 addInputFieldToInputsContainer api chatName =
   "inputs-container" `withElem` \inputsContainer -> do
@@ -199,6 +205,7 @@ pushToChatBox chatName str = ("chat-container-" ++ chatName) `withElem` \chatCon
   scrollToBottom chatContainer
   return ()
 
+-- | Set set the scrollTop property equal to the scrollHeight property.
 scrollToBottom :: Elem -> Client()
 scrollToBottom scrollableElem = do
   scrollHeight <- getProp scrollableElem "scrollHeight"

--- a/src/Views/Chat.hs
+++ b/src/Views/Chat.hs
@@ -216,8 +216,10 @@ clientJoinChat api chatName = do
   return ()
 
 clientLeaveChat :: LobbyAPI -> String -> Client ()
-clientLeaveChat api chatName = do
-  onServer $ leaveChat api <.> chatName
+clientLeaveChat api chatName =
+  if chatName == "main"
+    then pushToChatBox chatName "You can't leave the main chat"
+    else onServer $ leaveChat api <.> chatName
 
 
 -- | Called when a ChatMessage is received

--- a/src/Views/Chat.hs
+++ b/src/Views/Chat.hs
@@ -170,25 +170,29 @@ deleteChat chatName = do
 -- | All other chat elements are hidden.
 setActiveChat :: String -> Client ()
 setActiveChat chatName = do
+  "chat-tabs" `withElem` \chatTabs -> do
+    setClassOnChildren chatTabs ""
+    maybeDOMElem <- elemById $ "chat-tab-" ++ chatName
+    setClassOnMaybeDOMElem maybeDOMElem "active"
   "chat-container" `withElem` \chatContainer -> do
-    setHideClassOnChildren chatContainer
+    setClassOnChildren chatContainer "hide"
     maybeDOMElem <- elemById $ "chat-container-" ++ chatName
-    clearClassAttrOnMaybeDomElem maybeDOMElem
+    setClassOnMaybeDOMElem maybeDOMElem ""
   "input-container" `withElem` \inputs -> do
-    setHideClassOnChildren inputs
+    setClassOnChildren inputs "hide"
     maybeDOMElem <- elemById $ "input-field-" ++ chatName
-    clearClassAttrOnMaybeDomElem maybeDOMElem
+    setClassOnMaybeDOMElem maybeDOMElem ""
   return ()
     where
-      setHideClassOnChildren parent = do
+      setClassOnChildren parent value = do
         children <- getChildren parent
-        mapM_ (\c -> setAttr c "class" "hide") children
+        mapM_ (\c -> setAttr c "class" value) children
 
-      clearClassAttrOnMaybeDomElem maybeDOMElem = do
+      setClassOnMaybeDOMElem maybeDOMElem attr = do
         case maybeDOMElem of
           Nothing   -> return ()
           Just chat -> do
-            setAttr chat "class" ""
+            setAttr chat "class" attr
             scrollToBottom chat
 
 -- | Client joins the named chat and starts listen to it's messages

--- a/src/Views/Chat.hs
+++ b/src/Views/Chat.hs
@@ -238,7 +238,7 @@ chatMessageCallback api chatName (ChatAnnounceLeave from)   = do
     else return ()
 chatMessageCallback api chatName (ChatError errorMessage)   = do
   liftIO $ print $ "chatMessageCallback > " ++ "ChatError" ++ errorMessage
-  pushToChatBox chatName $ "ChatError" ++ errorMessage
+  pushToChatBox "main" $ "ChatError" ++ errorMessage
 chatMessageCallback api chatName _ =
   liftIO $ print $ "chatMessageCallback > Bad ChatMessage on chat " ++ chatName
 

--- a/src/Views/Chat.hs
+++ b/src/Views/Chat.hs
@@ -172,16 +172,16 @@ setActiveChat :: String -> Client ()
 setActiveChat chatName = do
   "chat-tabs" `withElem` \chatTabs -> do
     setClassOnChildren chatTabs ""
-    maybeDOMElem <- elemById $ "chat-tab-" ++ chatName
-    setClassOnMaybeDOMElem maybeDOMElem "active"
+    maybeChatTab <- elemById $ "chat-tab-" ++ chatName
+    setClassOnMaybeDOMElem maybeChatTab "active"
   "chat-container" `withElem` \chatContainer -> do
     setClassOnChildren chatContainer "hide"
-    maybeDOMElem <- elemById $ "chat-container-" ++ chatName
-    setClassOnMaybeDOMElem maybeDOMElem ""
+    maybeChatContainer <- elemById $ "chat-container-" ++ chatName
+    setClassOnMaybeDOMElem maybeChatContainer ""
   "input-container" `withElem` \inputs -> do
     setClassOnChildren inputs "hide"
-    maybeDOMElem <- elemById $ "input-field-" ++ chatName
-    setClassOnMaybeDOMElem maybeDOMElem ""
+    maybeInputField <- elemById $ "input-field-" ++ chatName
+    setClassOnMaybeDOMElem maybeInputField ""
   return ()
     where
       setClassOnChildren parent value = do

--- a/src/Views/Chat.hs
+++ b/src/Views/Chat.hs
@@ -113,7 +113,7 @@ addNewChatToChatsContainer chatName =
     chatContainer <- newElem "div" `with`
       [
         attr "id" =: ("chat-container-" ++ chatName),
-        attr "class" =: "tab-pane"
+        attr "style" =: "overflow: auto; height: 200px"
       ]
     appendChild chatsContainer chatContainer
 
@@ -148,7 +148,13 @@ pushToChatBox str = "chat-container-main" `withElem` \chatContainer -> do
   appendChild chatContainer br
   textElem <- newTextElem str
   appendChild chatContainer textElem
+  scrollToBottom chatContainer
   return ()
+
+scrollToBottom :: Elem -> Client()
+scrollToBottom scrollableElem = do
+  scrollHeight <- getProp scrollableElem "scrollHeight"
+  setProp scrollableElem "scrollTop" scrollHeight
 
 -- |Listen for chat messages on a chatChannel until the chat announces that the client leaves
 -- |Start this method with fork $ listenForChatMessage args...


### PR DESCRIPTION
Fully fledged chat. resolves #3 
I currently know of two debatable flaws:

The `msg` command built in can send message to a chat the client hasn't joined.
For example:
`/msg foo Lorem ipsum dolor sit amet`
will send "Lorem ipsum dolor sit amet" to the channel `foo`. regardless if the client is in that chat or not.
Whether we want it like this or not i don't know. It's an easy fix if we only want the clients to be able to send chat messages to chats they've joined but I'll leave it like this for now.

The other flaw happen when two players have the same name.
Say two clients both have chosen the name `apa` and they have joined the channel `foo`.
If either one of them now decides to `/leave` the chat then the other will get kicked out as well.
