### PR TITLE
Feature/password protected games

### DIFF
--- a/Hastings.cabal
+++ b/Hastings.cabal
@@ -16,7 +16,9 @@ cabal-version:       >=1.10
 library
   hs-source-dirs:      src
   build-depends:
-    base >= 4.7 && < 5
+    base >= 4.7 && < 5,
+    pwstore-fast,
+    bytestring
   exposed-modules: Views.Chat Views.Lobby, Views.Common, Views.Game, LobbyTypes, Hastings.Utils, LobbyClient, LobbyAPI, GameAPI
   if impl(haste)
     build-depends: haste-lib >= 0.5 && < 0.6
@@ -36,7 +38,9 @@ executable Hastings-exe
   build-depends:
    base      >= 4.8 && < 4.9,
    Hastings,
-   haste-standalone
+   haste-standalone,
+   pwstore-fast,
+   bytestring
  if impl(haste)
    build-depends: haste-lib >= 0.5 && < 0.6
  else

--- a/Hastings.cabal
+++ b/Hastings.cabal
@@ -17,7 +17,6 @@ library
   hs-source-dirs:      src
   build-depends:
     base >= 4.7 && < 5,
-    pwstore-fast,
     bytestring
   exposed-modules: Views.Chat Views.Lobby, Views.Common, Views.Game, LobbyTypes, Hastings.Utils, LobbyClient, LobbyAPI, GameAPI
   if impl(haste)
@@ -27,7 +26,8 @@ library
     build-depends:
       haste-compiler >= 0.5 && < 0.6,
       uuid,
-      random
+      random,
+      pwstore-fast
   --  build-depends: containers
   default-language:    Haskell2010
 
@@ -39,7 +39,6 @@ executable Hastings-exe
    base      >= 4.8 && < 4.9,
    Hastings,
    haste-standalone,
-   pwstore-fast,
    bytestring
  if impl(haste)
    build-depends: haste-lib >= 0.5 && < 0.6
@@ -47,7 +46,8 @@ executable Hastings-exe
    build-depends:
     haste-compiler >= 0.5 && < 0.6,
     uuid,
-    random
+    random,
+    pwstore-fast
   default-language:    Haskell2010
 
 test-suite Hastings-test

--- a/Hastings.cabal
+++ b/Hastings.cabal
@@ -60,7 +60,8 @@ test-suite Hastings-test
     haste-compiler,
     test-framework,
     test-framework-quickcheck2,
-    QuickCheck
+    QuickCheck,
+    bytestring
   other-modules:       Utils, Hastings.ServerUtilsTests
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010

--- a/src/LobbyAPI.hs
+++ b/src/LobbyAPI.hs
@@ -18,8 +18,9 @@ data LobbyAPI = LobbyAPI
   , createGame :: Remote (Int -> Server (Maybe (String)))
   , getGamesList :: Remote (Server [String])
     -- |Joins a game with the 'UUID' representetd by the 'String'.
+    -- |The second 'String' is the password for the game, can be left as "" if there is no password.
     -- |Returns if the client successfully joined or not.
-  , joinGame :: Remote (String -> Server Bool)
+  , joinGame :: Remote (String -> String -> Server Bool)
   , findPlayersInGame :: Remote (Server [String])
     -- |Finds the name of the game with String as identifier
   , findGameNameWithID :: Remote (String -> Server String)

--- a/src/LobbyAPI.hs
+++ b/src/LobbyAPI.hs
@@ -15,7 +15,7 @@ data LobbyAPI = LobbyAPI
   { connect :: Remote (String -> Server ())
     -- |Creates a game on the server with the current client as host.
     -- |The 'Int' represents the default max number of players
-  , createGame :: Remote (Int -> Server (Maybe (String)))
+  , createGame :: Remote (Int -> Server (Maybe String))
   , getGamesList :: Remote (Server [String])
     -- |Joins a game with the 'UUID' representetd by the 'String'.
     -- |The second 'String' is the password for the game, can be left as "" if there is no password.

--- a/src/LobbyAPI.hs
+++ b/src/LobbyAPI.hs
@@ -50,6 +50,8 @@ data LobbyAPI = LobbyAPI
   , setPassword :: Remote (String -> Server ())
     -- |Returns if the game is protected by a password or not. 'String' is the Game ID
   , isGamePasswordProtected :: Remote (String -> Server Bool)
+    -- |Returns whether or not the current player is owner of the game it's in
+  , isOwnerOfCurrentGame :: Remote (Server Bool)
   }
 
 -- |Creates an instance of the api used by the client to communicate with the server.
@@ -74,3 +76,4 @@ newLobbyAPI (playersList, gamesList, chatList) =
             <*> REMOTE((Server.readChatChannel playersList))
             <*> REMOTE((Server.setPasswordToGame gamesList))
             <*> REMOTE((Server.isGamePasswordProtected gamesList))
+            <*> REMOTE((Server.isOwnerOfGame gamesList))

--- a/src/LobbyAPI.hs
+++ b/src/LobbyAPI.hs
@@ -7,7 +7,7 @@ import LobbyTypes
 #ifdef __HASTE__
 #define REMOTE(x) (remote undefined)
 #else
-import LobbyServer as Server
+import qualified LobbyServer as Server
 #define REMOTE(x) (remote x)
 #endif
 -- |The api provided by the server.
@@ -44,6 +44,11 @@ data LobbyAPI = LobbyAPI
   , sendChatMessage :: Remote (Name -> ChatMessage -> Server ())
     -- |Reads next ChatMessage from named chat channel.
   , readChatChannel :: Remote (Name -> Server ChatMessage)
+    -- |Sets a password to the game the client is in as 'ByteString'
+    -- |Only allowed if the current player is owner of it's game
+  , setPassword :: Remote (String -> Server ())
+    -- |Returns if the game is protected by a password or not. 'String' is the Game ID
+  , isGamePasswordProtected :: Remote (String -> Server Bool)
   }
 
 -- |Creates an instance of the api used by the client to communicate with the server.
@@ -66,3 +71,5 @@ newLobbyAPI (playersList, gamesList, chatList) =
             <*> REMOTE((Server.joinChat playersList chatList))
             <*> REMOTE((Server.sendChatMessage playersList chatList))
             <*> REMOTE((Server.readChatChannel playersList))
+            <*> REMOTE((Server.setPasswordToGame gamesList))
+            <*> REMOTE((Server.isGamePasswordProtected gamesList))

--- a/src/LobbyClient.hs
+++ b/src/LobbyClient.hs
@@ -59,4 +59,6 @@ listenForLobbyChanges api gapi = do
     playerLeftGameFun = do
       updatePlayerListGame api
       isOwner <- onServer $ isOwnerOfCurrentGame api
-      when isOwner $ createGameOwnerDOM api gapi
+      when isOwner $ do
+        deleteGameOwnerDOM
+        createGameOwnerDOM api gapi

--- a/src/LobbyClient.hs
+++ b/src/LobbyClient.hs
@@ -47,7 +47,13 @@ listenForLobbyChanges api gapi = do
     ClientJoined     -> updatePlayerList api
     ClientLeft       -> do
       updatePlayerList api
-      updatePlayerListGame api
+      playerLeftGameFun
     PlayerJoinedGame -> updatePlayerListGame api
+    PlayerLeftGame   -> playerLeftGameFun
     (LobbyError msg) -> liftIO $ print msg -- Update with some way to show error to client
   listenForLobbyChanges api gapi
+  where
+    playerLeftGameFun = do
+      updatePlayerListGame api
+      isOwner <- onServer $ isOwnerOfCurrentGame api
+      when isOwner $ createGameOwnerDOM api gapi

--- a/src/LobbyClient.hs
+++ b/src/LobbyClient.hs
@@ -1,13 +1,16 @@
 -- |Module for all of the client only code
 module LobbyClient where
+import Haste.App
+import Haste.DOM
+import Haste.Concurrent
+
+import Data.Maybe
+import Control.Monad (when)
+
 import Views.Common
 import Views.Lobby
 import Views.Game
-import Haste.App
 import LobbyAPI
-import Haste.DOM
-import Haste.Concurrent
-import Data.Maybe
 import GameAPI
 import LobbyTypes
 import Views.Chat

--- a/src/LobbyServer.hs
+++ b/src/LobbyServer.hs
@@ -21,7 +21,9 @@ module LobbyServer(
   readChatChannel,
   sendChatMessage,
   joinChat,
-  getClientName) where
+  getClientName,
+  setPasswordToGame,
+  isGamePasswordProtected) where
 
 import Haste.App
 import qualified Control.Concurrent as CC

--- a/src/LobbyServer.hs
+++ b/src/LobbyServer.hs
@@ -228,9 +228,11 @@ kickPlayerWithSid remoteGames clientName = do
     Just game@(_,gameData) -> do
       liftIO $ CC.modifyMVar_ mVarGamesList $ \games ->
         return $ updateListElem (deletePlayerFromGame clientName) (== game) games
-      case findClient clientName (players gameData) of
-        Just c  -> liftIO $ messageClients KickedFromGame [c]
-        Nothing -> return ()
+      maybe
+        (return ())
+        (\c -> liftIO $ messageClients KickedFromGame [c])
+        (findClient clientName (players gameData))
+      liftIO $ messageClients PlayerLeftGame $ players gameData
 
 -- |Change the nick name of the current player to that given.
 changeNickName :: Server ConcurrentClientList -> Server GamesList -> Name -> Server ()

--- a/src/LobbyServer.hs
+++ b/src/LobbyServer.hs
@@ -26,16 +26,18 @@ module LobbyServer(
   isGamePasswordProtected) where
 
 import Haste.App
+
 import qualified Control.Concurrent as CC
+import Control.Monad (when)
+
 import Data.List
 import Data.Maybe
+import Data.ByteString.Char8 (ByteString, empty, pack, unpack)
+
+import Crypto.PasswordStore (makePassword, verifyPassword)
+
 import LobbyTypes
 import Hastings.Utils
-
-import Data.ByteString.Char8 (ByteString, empty, pack, unpack)
-import Crypto.PasswordStore
-
-import Control.Monad
 
 #ifndef __HASTE__
 import Data.UUID

--- a/src/LobbyServer.hs
+++ b/src/LobbyServer.hs
@@ -98,7 +98,7 @@ createGame remoteGames remoteClientList maxPlayers = do
 
   liftIO $ CC.modifyMVar_ games $ \gs ->
     case maybeClientEntry of
-        Just c  -> return $ (uuidStr, GameData [c] "GameName" maxPlayers) : gs
+        Just c  -> return $ (uuidStr, GameData [c] "GameName" maxPlayers "") : gs
         Nothing -> return gs
   liftIO $ messageClients GameAdded clientList
   case maybeClientEntry of

--- a/src/LobbyServer.hs
+++ b/src/LobbyServer.hs
@@ -434,10 +434,10 @@ setPasswordToGame remoteGames passwordString = do
           games
     (Just (_,gameData), False) -> do
       sid <- getSessionID
-      case lookupClientEntry sid (players gameData) of
-        Nothing     -> return ()
-        Just client -> return () -- Message client with error when available
-                                 -- messageClients (LobbyError "Not owner of the game") client
+      maybe
+        (return ())
+        (\client -> liftIO $ messageClients (LobbyError "Not owner of the game") [client])
+        (lookupClientEntry sid (players gameData))
 
 -- |Returns True if game is password protected, False otherwise. 'String' is the UUID of the game
 isGamePasswordProtected :: Server GamesList -> String -> Server Bool

--- a/src/LobbyServer.hs
+++ b/src/LobbyServer.hs
@@ -295,6 +295,9 @@ readLobbyChannel remoteClientList = do
 findClient :: Name -> [ClientEntry] -> Maybe ClientEntry
 findClient clientName = find ((clientName ==).name)
 
+findClientSid :: SessionID -> [ClientEntry] -> Maybe ClientEntry
+findClientSid sid = find ((sid ==).sessionID)
+
 -- |Maps over the clients and writes the message to their channel
 messageClients :: LobbyMessage -> [ClientEntry] -> IO ()
 messageClients m = mapM_ (\c -> CC.writeChan (lobbyChannel c) m)

--- a/src/LobbyServer.hs
+++ b/src/LobbyServer.hs
@@ -108,13 +108,9 @@ createGame remoteGames remoteClientList maxPlayers = do
   let uuidStr = Data.UUID.toString uuid
 
   liftIO $ CC.modifyMVar_ games $ \gs ->
-    case maybeClientEntry of
-        Just c  -> return $ (uuidStr, GameData [c] "GameName" maxPlayers empty) : gs
-        Nothing -> return gs
+    return $ maybe gs (\c -> (uuidStr, GameData [c] "GameName" maxPlayers empty) : gs) maybeClientEntry
   liftIO $ messageClients GameAdded clientList
-  case maybeClientEntry of
-    Just p  -> return $ Just uuidStr
-    Nothing -> return Nothing
+  return $ maybe Nothing (\_ -> Just uuidStr) maybeClientEntry
 
 -- |Returns a list of the each game's uuid as a String
 getGamesList :: Server GamesList -> Server [String]

--- a/src/LobbyServer.hs
+++ b/src/LobbyServer.hs
@@ -29,10 +29,15 @@ import Data.List
 import Data.Maybe
 import LobbyTypes
 import Hastings.Utils
+
+import Data.ByteString.Char8 (ByteString, empty, pack, unpack)
+import Crypto.PasswordStore
+
 #ifndef __HASTE__
 import Data.UUID
 import System.Random
 #endif
+
 
 -- |Initial connection with the server
 -- Creates a 'Player' for that user given a name.
@@ -98,7 +103,7 @@ createGame remoteGames remoteClientList maxPlayers = do
 
   liftIO $ CC.modifyMVar_ games $ \gs ->
     case maybeClientEntry of
-        Just c  -> return $ (uuidStr, GameData [c] "GameName" maxPlayers "") : gs
+        Just c  -> return $ (uuidStr, GameData [c] "GameName" maxPlayers empty) : gs
         Nothing -> return gs
   liftIO $ messageClients GameAdded clientList
   case maybeClientEntry of

--- a/src/LobbyServer.hs
+++ b/src/LobbyServer.hs
@@ -437,3 +437,12 @@ setPasswordToGame remoteGames unPackedPassword = do
         Nothing     -> return ()
         Just client -> return () -- Message client with error when available
                                  -- messageClients (LobbyError "Not owner of the game") client
+
+-- |Returns True if game is password protected, False otherwise. 'String' is the UUID of the game
+isGamePasswordProtected :: Server GamesList -> String -> Server Bool
+isGamePasswordProtected remoteGames guuid = do
+  mVarGames <- remoteGames
+  maybeGame <- liftIO $ findGameWithID guuid mVarGames
+  case maybeGame of
+    Nothing           -> return False
+    Just (_,gameData) -> return $ gamePassword gameData /= empty

--- a/src/LobbyServer.hs
+++ b/src/LobbyServer.hs
@@ -301,9 +301,6 @@ readLobbyChannel remoteClientList = do
 findClient :: Name -> [ClientEntry] -> Maybe ClientEntry
 findClient clientName = find ((clientName ==).name)
 
-findClientSid :: SessionID -> [ClientEntry] -> Maybe ClientEntry
-findClientSid sid = find ((sid ==).sessionID)
-
 -- |Maps over the clients and writes the message to their channel
 messageClients :: LobbyMessage -> [ClientEntry] -> IO ()
 messageClients m = mapM_ (\c -> CC.writeChan (lobbyChannel c) m)
@@ -437,7 +434,7 @@ setPasswordToGame remoteGames passwordString = do
           games
     (Just (_,gameData), False) -> do
       sid <- getSessionID
-      case findClientSid sid (players gameData) of
+      case lookupClientEntry sid (players gameData) of
         Nothing     -> return ()
         Just client -> return () -- Message client with error when available
                                  -- messageClients (LobbyError "Not owner of the game") client

--- a/src/LobbyServer.hs
+++ b/src/LobbyServer.hs
@@ -424,8 +424,8 @@ getClientName remoteClientList = do
 -- |Sets the password (as a 'ByteString') of the game the client is in.
 -- |Only possible if the client is the owner of the game.
 setPasswordToGame :: Server GamesList -> String -> Server ()
-setPasswordToGame remoteGames unPackedPassword = do
-  let password = pack unPackedPassword
+setPasswordToGame remoteGames passwordString = do
+  let password = pack passwordString
   hashedPassword <- liftIO $ makePassword password 17
   mVarGames <- remoteGames
   maybeGame <- findGameWithSid mVarGames

--- a/src/LobbyServer.hs
+++ b/src/LobbyServer.hs
@@ -23,7 +23,8 @@ module LobbyServer(
   joinChat,
   getClientName,
   setPasswordToGame,
-  isGamePasswordProtected) where
+  isGamePasswordProtected,
+  isOwnerOfGame) where
 
 import Haste.App
 

--- a/src/LobbyTypes.hs
+++ b/src/LobbyTypes.hs
@@ -93,8 +93,7 @@ lookupClientEntry sid = find ((sid ==) . sessionID)
 
 -- |LobbyMessage is a message to a client idicating some udate to the state that the cliet has to adapt to.
 data LobbyMessage = NickChange | GameNameChange | KickedFromGame | GameAdded | ClientJoined
-      | ClientLeft | PlayerJoinedGame | LobbyError {lobbyErrorMessage :: String}
-  deriving (Eq)
+      | ClientLeft | PlayerJoinedGame | PlayerLeftGame | LobbyError {lobbyErrorMessage :: String}
 
 instance Binary LobbyMessage where
   put NickChange       = put (0 :: Word8)
@@ -104,8 +103,9 @@ instance Binary LobbyMessage where
   put ClientJoined     = put (4 :: Word8)
   put ClientLeft       = put (5 :: Word8)
   put PlayerJoinedGame = put (6 :: Word8)
+  put PlayerLeftGame   = put (7 :: Word8)
   put (LobbyError msg) = do
-    put (7 :: Word8)
+    put (8 :: Word8)
     put msg
 
   get = do
@@ -118,7 +118,8 @@ instance Binary LobbyMessage where
       4 -> return ClientJoined
       5 -> return ClientLeft
       6 -> return PlayerJoinedGame
-      7 -> do
+      7 -> return PlayerLeftGame
+      8 -> do
         msg <- get :: Get String
         return $ LobbyError msg
 

--- a/src/LobbyTypes.hs
+++ b/src/LobbyTypes.hs
@@ -5,6 +5,7 @@ import Haste.App
 import Data.List
 import Data.Word
 import Haste.Binary (Binary, Get)
+import Data.ByteString.Char8 (ByteString)
 
 -- |A type synonym to clarify that some Strings are Names.
 type Name = String
@@ -29,7 +30,7 @@ type LobbyGame = (String, GameData)
 data GameData = GameData {players            :: [ClientEntry],
                           gameName           :: Name,
                           maxAmountOfPlayers :: Int,
-                          gamePassword       :: String}
+                          gamePassword       :: ByteString}
   deriving (Eq)
 
 -- |A list of all the 'LobbyGame's that have been started inside the Lobby.

--- a/src/LobbyTypes.hs
+++ b/src/LobbyTypes.hs
@@ -28,7 +28,8 @@ type LobbyGame = (String, GameData)
 -- |The maximum allowed players, can be changed by the owner
 data GameData = GameData {players            :: [ClientEntry],
                           gameName           :: Name,
-                          maxAmountOfPlayers :: Int}
+                          maxAmountOfPlayers :: Int,
+                          gamePassword       :: String}
   deriving (Eq)
 
 -- |A list of all the 'LobbyGame's that have been started inside the Lobby.

--- a/src/Views/Common.hs
+++ b/src/Views/Common.hs
@@ -53,10 +53,10 @@ deleteLobbyDOM = deleteDOM "lobby" "centerContent"
 -- |Deletes the DOM created for a game in the lobby
 deleteGameDOM :: Client ()
 deleteGameDOM = do
-  deleteDOM "lobbyGame" "centerContent"
-  deleteDOM "gameNameDiv" "rightContent"
-  deleteDOM "maxNumberDiv" "rightContent"
-  deleteDOM "setPasswordDiv" "rightContent"
+  deleteDOM "lobby-game" "centerContent"
+  deleteDOM "game-name-div" "rightContent"
+  deleteDOM "max-number-div" "rightContent"
+  deleteDOM "set-password-div" "rightContent"
 
 -- |Helper function that deletes DOM given an identifier from that element and the parent element
 deleteDOM :: String -> String -> Client ()
@@ -101,13 +101,13 @@ addChildrenToParent' parent = mapM_ (appendChild parent)
 -- |The field and button is then placed in the right sidebar.
 createInputFieldWithButton :: String -> String -> Client () -> Client ()
 createInputFieldWithButton identifier text function = do
-  parentDiv <- createDiv [("id", identifier ++ "Div")]
+  parentDiv <- createDiv [("id", identifier ++ "-div")]
   setClass parentDiv "input-group" True
 
   inputField <- newElem "input" `with`
     [
       attr "type" =: "text",
-      attr "id" =: (identifier ++ "Field"),
+      attr "id" =: (identifier ++ "-field"),
       attr "placeholder" =: text
     ]
   setClass inputField "form-control" True
@@ -116,7 +116,7 @@ createInputFieldWithButton identifier text function = do
   setClass buttonSpan "input-group-btn" True
   button <- newElem "button" `with`
     [
-      attr "id" =: (identifier ++ "Btn"),
+      attr "id" =: (identifier ++ "-btn"),
       attr "type" =: "button"
     ]
 
@@ -132,7 +132,7 @@ createInputFieldWithButton identifier text function = do
 
   onEvent inputField KeyPress $ \13 -> function
 
-  clickEventString (identifier ++ "Btn") function
+  clickEventString (identifier ++ "-btn") function
   return ()
 
 -- |Displays the error message in 'String'. Fades in the message and then out.

--- a/src/Views/Common.hs
+++ b/src/Views/Common.hs
@@ -97,7 +97,7 @@ addChildrenToParent' parent children = mapM_ (appendChild parent) children
 -- |Div is created with id = identifier ++ "Div". Field is created with id = identifier ++ "Field".
 -- |Button is created with id = identifier ++ "Btn"
 -- |The field and button is then placed in the right sidebar.
-createInputFieldWithButton :: String -> String -> (Client ()) -> Client ()
+createInputFieldWithButton :: String -> String -> Client () -> Client ()
 createInputFieldWithButton identifier text function = do
   parentDiv <- createDiv [("id", identifier ++ "Div")]
 

--- a/src/Views/Common.hs
+++ b/src/Views/Common.hs
@@ -91,3 +91,32 @@ addChildrenToParent parent children = do
 
 addChildrenToParent' :: Elem -> [Elem] -> Client ()
 addChildrenToParent' parent children = mapM_ (appendChild parent) children
+
+-- |Creates an input field and button. Has 'String' as id and '(Client ())' is the function
+-- |That activates when clicking button or pressing enter. Descriptive text is second 'String'
+createInputFieldWithButton :: String -> String -> (Client ()) -> Client ()
+createInputFieldWithButton identifier text function = do
+  parentDiv <- createDiv [("id", identifier ++ "Div")]
+
+  textElement <- newTextElem text
+  inputField <- newElem "input" `with`
+    [
+      attr "type" =: "text",
+      attr "id" =: (identifier ++ "Field")
+    ]
+  button <- newElem "button" `with`
+    [
+      attr "id" =: (identifier ++ "Btn")
+    ]
+  buttonText <- newTextElem "Change"
+
+  appendChild button buttonText
+  appendChild parentDiv textElement
+  appendChild parentDiv inputField
+  appendChild parentDiv button
+  addChildrenToRightColumn [parentDiv]
+
+  onEvent inputField KeyPress $ \13 -> function
+
+  clickEventString (identifier ++ "Btn") function
+  return ()

--- a/src/Views/Common.hs
+++ b/src/Views/Common.hs
@@ -54,7 +54,9 @@ deleteLobbyDOM = deleteDOM "lobby" "centerContent"
 deleteGameDOM :: Client ()
 deleteGameDOM = do
   deleteDOM "lobbyGame" "centerContent"
-  deleteDOM "changeGameName" "rightContent"
+  deleteDOM "gameNameDiv" "rightContent"
+  deleteDOM "maxNumberDiv" "rightContent"
+  deleteDOM "setPasswordDiv" "rightContent"
 
 -- |Helper function that deletes DOM given an identifier from that element and the parent element
 deleteDOM :: String -> String -> Client ()

--- a/src/Views/Common.hs
+++ b/src/Views/Common.hs
@@ -102,23 +102,32 @@ addChildrenToParent' parent children = mapM_ (appendChild parent) children
 createInputFieldWithButton :: String -> String -> Client () -> Client ()
 createInputFieldWithButton identifier text function = do
   parentDiv <- createDiv [("id", identifier ++ "Div")]
+  setClass parentDiv "input-group" True
 
-  textElement <- newTextElem text
   inputField <- newElem "input" `with`
     [
       attr "type" =: "text",
-      attr "id" =: (identifier ++ "Field")
+      attr "id" =: (identifier ++ "Field"),
+      attr "placeholder" =: text
     ]
+  setClass inputField "form-control" True
+
+  buttonSpan <- newElem "span"
+  setClass buttonSpan "input-group-btn" True
   button <- newElem "button" `with`
     [
-      attr "id" =: (identifier ++ "Btn")
+      attr "id" =: (identifier ++ "Btn"),
+      attr "type" =: "button"
     ]
+
+  setClass button "btn" True
+  setClass button "btn-default" True
   buttonText <- newTextElem "Change"
 
   appendChild button buttonText
-  appendChild parentDiv textElement
+  appendChild buttonSpan button
   appendChild parentDiv inputField
-  appendChild parentDiv button
+  appendChild parentDiv buttonSpan
   addChildrenToRightColumn [parentDiv]
 
   onEvent inputField KeyPress $ \13 -> function

--- a/src/Views/Common.hs
+++ b/src/Views/Common.hs
@@ -54,9 +54,27 @@ deleteLobbyDOM = deleteDOM "lobby" "centerContent"
 deleteGameDOM :: Client ()
 deleteGameDOM = do
   deleteDOM "lobby-game" "centerContent"
-  deleteDOM "game-name-div" "rightContent"
-  deleteDOM "max-number-div" "rightContent"
-  deleteDOM "set-password-div" "rightContent"
+  deleteGameOwnerDOM
+
+-- |Deletes the DOM created for changing settings in a game
+deleteGameOwnerDOM :: Client ()
+deleteGameOwnerDOM = do
+  deleteDomSafe "game-name-div" "rightContent"
+  deleteDomSafe "max-number-div" "rightContent"
+  deleteDomSafe "set-password-div" "rightContent"
+
+-- |Helper function that deletes DOM, but checks if the elements exists first
+deleteDomSafe :: String  -- ^The id of the element to remove
+              -> String  -- ^The id of the parent of the element to remove
+              -> Client ()
+deleteDomSafe child parent = do
+  childElem  <- elemById child
+  parentElem <- elemById parent
+  case (childElem, parentElem) of
+    (Just c, Just p) -> deleteChild p c
+    _                -> return ()
+
+
 
 -- |Helper function that deletes DOM given an identifier from that element and the parent element
 deleteDOM :: String -> String -> Client ()

--- a/src/Views/Common.hs
+++ b/src/Views/Common.hs
@@ -101,27 +101,26 @@ addChildrenToParent' parent = mapM_ (appendChild parent)
 -- |The field and button is then placed in the right sidebar.
 createInputFieldWithButton :: String -> String -> Client () -> Client ()
 createInputFieldWithButton identifier text function = do
-  parentDiv <- createDiv [("id", identifier ++ "-div")]
-  setClass parentDiv "input-group" True
+  parentDiv <- createDiv [("id", identifier ++ "-div"),("class","input-group")]
 
   inputField <- newElem "input" `with`
     [
-      attr "type" =: "text",
-      attr "id" =: (identifier ++ "-field"),
-      attr "placeholder" =: text
+      attr "type"        =: "text",
+      attr "id"          =: (identifier ++ "-field"),
+      attr "placeholder" =: text,
+      attr "class"       =: "form-control"
     ]
-  setClass inputField "form-control" True
 
-  buttonSpan <- newElem "span"
-  setClass buttonSpan "input-group-btn" True
+  buttonSpan <- newElem "span" `with`
+    [
+      attr "class" =: "input-group-btn"
+    ]
   button <- newElem "button" `with`
     [
-      attr "id" =: (identifier ++ "-btn"),
-      attr "type" =: "button"
+      attr "id"    =: (identifier ++ "-btn"),
+      attr "type"  =: "button",
+      attr "class" =: "btn btn-default"
     ]
-
-  setClass button "btn" True
-  setClass button "btn-default" True
   buttonText <- newTextElem "Change"
 
   appendChild button buttonText

--- a/src/Views/Common.hs
+++ b/src/Views/Common.hs
@@ -94,6 +94,9 @@ addChildrenToParent' parent children = mapM_ (appendChild parent) children
 
 -- |Creates an input field and button. Has 'String' as id and '(Client ())' is the function
 -- |That activates when clicking button or pressing enter. Descriptive text is second 'String'
+-- |Div is created with id = identifier ++ "Div". Field is created with id = identifier ++ "Field".
+-- |Button is created with id = identifier ++ "Btn"
+-- |The field and button is then placed in the right sidebar.
 createInputFieldWithButton :: String -> String -> (Client ()) -> Client ()
 createInputFieldWithButton identifier text function = do
   parentDiv <- createDiv [("id", identifier ++ "Div")]

--- a/src/Views/Game.hs
+++ b/src/Views/Game.hs
@@ -91,36 +91,6 @@ createUpdateMaxNumberPlayersDOM api gapi =
           Nothing   -> return ()
 
 
--- |Creates an input field and button. Has 'String' as id and '(Client ())' is the function
--- |That activates when clicking button or pressing enter. Descriptive text is second 'String'
-createInputFieldWithButton :: String -> String -> (Client ()) -> Client ()
-createInputFieldWithButton identifier text function = do
-  parentDiv <- createDiv [("id", identifier ++ "Div")]
-
-  textElement <- newTextElem text
-  inputField <- newElem "input" `with`
-    [
-      attr "type" =: "text",
-      attr "id" =: (identifier ++ "Field")
-    ]
-  button <- newElem "button" `with`
-    [
-      attr "id" =: (identifier ++ "Btn")
-    ]
-  buttonText <- newTextElem "Change"
-
-  appendChild button buttonText
-  appendChild parentDiv textElement
-  appendChild parentDiv inputField
-  appendChild parentDiv button
-  addChildrenToRightColumn [parentDiv]
-
-  onEvent inputField KeyPress $ \13 -> function
-
-  clickEventString (identifier ++ "Btn") function
-  return ()
-
-
 -- |Convenience function for calling on the kick function.
 kickFunction :: Name -> LobbyAPI -> Client ()
 kickFunction name api = onServer $ kickPlayer api <.> name

--- a/src/Views/Game.hs
+++ b/src/Views/Game.hs
@@ -58,31 +58,7 @@ createGameDOM api gapi = do
 -- |Creates the DOM for chaning the name of a game.
 -- |It includes an input field and a button.
 createGameChangeNameDOM :: LobbyAPI -> Client ()
-createGameChangeNameDOM api = do
-  gameNameDiv <- createDiv [("id", "changeGameName")]
-  gameNameText <- newTextElem "Change game name"
-  gameNameField <- newElem "input" `with`
-    [
-      attr "type" =: "text",
-      attr "id" =: "gameNameField"
-    ]
-  gameNameButton <- newElem "button" `with`
-    [
-      attr "id" =: "gameNameBtn"
-    ]
-  gameNameBtnText <- newTextElem "Change"
-  appendChild gameNameButton gameNameBtnText
-
-  addChildrenToParent' gameNameDiv [gameNameText, gameNameField, gameNameButton]
-
-  addChildrenToRightColumn [gameNameDiv]
-
-  onEvent gameNameField KeyPress $ \13 -> gameUpdateFunction
-
-  clickEventString "gameNameBtn" gameUpdateFunction
-
-  return ()
-
+createGameChangeNameDOM api = createInputFieldWithButton "gameName" "Change game name" gameUpdateFunction
   where
     gameUpdateFunction =
       withElem "gameNameField" $ \field -> do
@@ -97,32 +73,8 @@ createGameChangeNameDOM api = do
 -- |Creates DOM for the updatin the maximum number of players in a game
 -- |Contains an input field and a button. Is placed in the right sidebar
 createUpdateMaxNumberPlayersDOM :: LobbyAPI -> GameAPI-> Client ()
-createUpdateMaxNumberPlayersDOM api gapi = do
-  maxNumberDiv <- createDiv [("id","maxNumberDiv")]
-
-  maxNumberText <- newTextElem "Change maximum number of players"
-  maxNumberField <- newElem "input" `with`
-    [
-      attr "type" =: "text",
-      attr "id" =: "maxNumberField"
-    ]
-  maxNumberButton <- newElem "button" `with`
-    [
-      attr "id" =: "maxNumberBtn"
-    ]
-  maxNumberBtnText <- newTextElem "Change"
-
-  appendChild maxNumberButton maxNumberBtnText
-  appendChild maxNumberDiv maxNumberText
-  appendChild maxNumberDiv maxNumberField
-  appendChild maxNumberDiv maxNumberButton
-  addChildrenToRightColumn [maxNumberDiv]
-
-  onEvent maxNumberField KeyPress $ \13 -> maxNumberUpdateFunction
-
-  clickEventString "maxNumberBtn" maxNumberUpdateFunction
-  return ()
-
+createUpdateMaxNumberPlayersDOM api gapi =
+  createInputFieldWithButton "maxNumber" "Change maximum number of players" maxNumberUpdateFunction
   where
     maxNumberUpdateFunction =
       withElem "maxNumberField" $ \field -> do

--- a/src/Views/Game.hs
+++ b/src/Views/Game.hs
@@ -13,6 +13,8 @@ import GameAPI
 
 import Text.Read
 
+import Control.Monad
+
 -- |Creates the DOM for a 'LobbyGame' inside the lobby
 -- Useful since the Client is unaware of the specific 'LobbyGame' but can get the name and list with 'Name's of players from the server.
 createGameDOM :: LobbyAPI -> GameAPI -> Client ()
@@ -152,11 +154,9 @@ addGame api gapi gameID = do
   where
     joinGameClient password = do
       allowedToJoin <- onServer $ joinGame api <.> gameID <.> password
-      if allowedToJoin then do
+      when allowedToJoin $ do
           deleteLobbyDOM
           createGameDOM api gapi
-      else
-        return ()
 
 -- |Updates the list of players in a game on the client
 updatePlayerListGame :: LobbyAPI -> Client ()

--- a/src/Views/Game.hs
+++ b/src/Views/Game.hs
@@ -14,8 +14,6 @@ import GameAPI
 
 import Text.Read
 
-import Control.Monad (when)
-
 -- |Creates the DOM for a 'LobbyGame' inside the lobby
 -- Useful since the Client is unaware of the specific 'LobbyGame' but can get the name and list with 'Name's of players from the server.
 createGameDOM :: LobbyAPI -> GameAPI -> Client ()
@@ -125,46 +123,6 @@ addPlayerWithKickToPlayerlist api parent name = do
   appendChild parent textElem
   appendChild parent kickBtn
   appendChild parent br
-
--- |Adds DOM for a game
-addGame :: LobbyAPI -> GameAPI -> String -> Client ()
-addGame api gapi gameID = do
-  maybeGameListDiv <- elemById "games-list-table-body"
-  case maybeGameListDiv of
-    Nothing -> return ()
-    Just gameListDiv -> do
-      gameName <- onServer $ findGameNameWithID api <.> gameID
-      tr <- newElem "tr"
-      tdBtn <- newElem "td"
-      gameEntry <- newElem "button" `with`
-        [
-          prop "id" =: gameName
-        ]
-      textElemBtn <- newTextElem "Join"
-
-      textElemName <- newTextElem gameName
-      tdName <- newElem "td"
-
-      appendChild gameEntry textElemBtn
-      appendChild tdBtn gameEntry
-      appendChild tdName textElemName
-      addChildrenToParent' tr [tdName, tdBtn]
-      appendChild gameListDiv tr
-
-      clickEventString gameName $ do
-        hasPassword <- onServer $ isGamePasswordProtected api <.> gameID
-        if hasPassword then do
-          password <- prompt "Enter password"
-          joinGameClient password
-        else
-          joinGameClient ""
-      return ()
-  where
-    joinGameClient password = do
-      allowedToJoin <- onServer $ joinGame api <.> gameID <.> password
-      when allowedToJoin $ do
-          deleteLobbyDOM
-          createGameDOM api gapi
 
 -- |Updates the list of players in a game on the client
 updatePlayerListGame :: LobbyAPI -> Client ()

--- a/src/Views/Game.hs
+++ b/src/Views/Game.hs
@@ -20,9 +20,8 @@ createGameDOM :: LobbyAPI -> GameAPI -> Client ()
 createGameDOM api gapi = do
   parentDiv <- createDiv [("id","lobby-game")]
 
-  createGameChangeNameDOM api
-  createUpdateMaxNumberPlayersDOM api gapi
-  createSetPasswordDOM api
+  isOwner <- onServer $ isOwnerOfCurrentGame api
+  when isOwner $ createGameOwnerDOM api gapi
 
   gameName <- onServer $ findGameName api
   players <- onServer $ findPlayersInGame api
@@ -56,6 +55,13 @@ createGameDOM api gapi = do
 
   addChildrenToParent' parentDiv [header, list, createStartGameBtn]
   addChildrenToCenterColumn [parentDiv]
+
+
+createGameOwnerDOM :: LobbyAPI -> GameAPI -> Client ()
+createGameOwnerDOM api gapi= do
+  createGameChangeNameDOM api
+  createUpdateMaxNumberPlayersDOM api gapi
+  createSetPasswordDOM api
 
 -- |Creates the DOM for chaning the name of a game.
 -- |It includes an input field and a button.

--- a/src/Views/Game.hs
+++ b/src/Views/Game.hs
@@ -57,9 +57,9 @@ createGameDOM api gapi = do
   addChildrenToParent' parentDiv [header, list, createStartGameBtn]
   addChildrenToCenterColumn [parentDiv]
 
-
+-- |Creates DOM for changing game settings
 createGameOwnerDOM :: LobbyAPI -> GameAPI -> Client ()
-createGameOwnerDOM api gapi= do
+createGameOwnerDOM api gapi = do
   createGameChangeNameDOM api
   createUpdateMaxNumberPlayersDOM api gapi
   createSetPasswordDOM api

--- a/src/Views/Game.hs
+++ b/src/Views/Game.hs
@@ -138,6 +138,37 @@ createUpdateMaxNumberPlayersDOM api gapi = do
                           | otherwise -> return ()
           Nothing   -> return ()
 
+
+-- |Creates an input field and button. Has 'String' as id and '(Client ())' is the function
+-- |That activates when clicking button or pressing enter. Descriptive text is second 'String'
+createInputFieldWithButton :: String -> String -> (Client ()) -> Client ()
+createInputFieldWithButton identifier text function = do
+  parentDiv <- createDiv [("id", identifier ++ "Div")]
+
+  textElement <- newTextElem text
+  inputField <- newElem "input" `with`
+    [
+      attr "type" =: "text",
+      attr "id" =: (identifier ++ "Field")
+    ]
+  button <- newElem "button" `with`
+    [
+      attr "id" =: (identifier ++ "Btn")
+    ]
+  buttonText <- newTextElem "Change"
+
+  appendChild button buttonText
+  appendChild parentDiv textElement
+  appendChild parentDiv inputField
+  appendChild parentDiv button
+  addChildrenToRightColumn [parentDiv]
+
+  onEvent inputField KeyPress $ \13 -> function
+
+  clickEventString (identifier ++ "Btn") function
+  return ()
+
+
 -- |Convenience function for calling on the kick function.
 kickFunction :: Name -> LobbyAPI -> Client ()
 kickFunction name api = onServer $ kickPlayer api <.> name

--- a/src/Views/Game.hs
+++ b/src/Views/Game.hs
@@ -61,7 +61,7 @@ createGameDOM api gapi = do
 -- |Creates the DOM for chaning the name of a game.
 -- |It includes an input field and a button.
 createGameChangeNameDOM :: LobbyAPI -> Client ()
-createGameChangeNameDOM api = createInputFieldWithButton "gameName" "Change game name" gameUpdateFunction
+createGameChangeNameDOM api = createInputFieldWithButton "gameName" "Game name" gameUpdateFunction
   where
     gameUpdateFunction =
       withElem "gameNameField" $ \field -> do
@@ -77,7 +77,7 @@ createGameChangeNameDOM api = createInputFieldWithButton "gameName" "Change game
 -- |Contains an input field and a button. Is placed in the right sidebar
 createUpdateMaxNumberPlayersDOM :: LobbyAPI -> GameAPI-> Client ()
 createUpdateMaxNumberPlayersDOM api gapi =
-  createInputFieldWithButton "maxNumber" "Change maximum number of players" maxNumberUpdateFunction
+  createInputFieldWithButton "maxNumber" "Maximum number of players" maxNumberUpdateFunction
   where
     maxNumberUpdateFunction =
       withElem "maxNumberField" $ \field -> do
@@ -96,7 +96,7 @@ createUpdateMaxNumberPlayersDOM api gapi =
 -- |Creates an input field for setting the password of a game.
 -- |Contains an input field and a button. Is placed in right sidebar.
 createSetPasswordDOM :: LobbyAPI -> Client ()
-createSetPasswordDOM api = createInputFieldWithButton "setPassword" "Set password for this game" setPasswordFunction
+createSetPasswordDOM api = createInputFieldWithButton "setPassword" "Set password" setPasswordFunction
   where
     setPasswordFunction =
       withElem "setPasswordField" $ \field -> do

--- a/src/Views/Game.hs
+++ b/src/Views/Game.hs
@@ -20,7 +20,7 @@ import Control.Monad
 -- Useful since the Client is unaware of the specific 'LobbyGame' but can get the name and list with 'Name's of players from the server.
 createGameDOM :: LobbyAPI -> GameAPI -> Client ()
 createGameDOM api gapi = do
-  parentDiv <- createDiv [("id","lobbyGame")]
+  parentDiv <- createDiv [("id","lobby-game")]
 
   createGameChangeNameDOM api
   createUpdateMaxNumberPlayersDOM api gapi
@@ -31,7 +31,7 @@ createGameDOM api gapi = do
   nameOfGame <- newTextElem gameName
   header <- newElem "h1" `with`
     [
-      attr "id" =: "gameHeader",
+      attr "id" =: "game-header",
       style "text-align" =: "center",
       style "margin-left" =: "auto",
       style "margin-right" =: "auto"
@@ -40,14 +40,14 @@ createGameDOM api gapi = do
 
   createStartGameBtn <- newElem "button" `with`
     [
-      prop "id" =: "startGameButton"
+      prop "id" =: "start-game-button"
     ]
   createStartGameBtnText <- newTextElem "Start game"
   appendChild createStartGameBtn createStartGameBtnText
 
   list <- newElem "div" `with`
     [
-      prop "id" =: "gamePlayerList"
+      prop "id" =: "game-player-list"
     ]
   listhead <- newTextElem "Players: "
   br <- newElem "br"
@@ -62,10 +62,10 @@ createGameDOM api gapi = do
 -- |Creates the DOM for chaning the name of a game.
 -- |It includes an input field and a button.
 createGameChangeNameDOM :: LobbyAPI -> Client ()
-createGameChangeNameDOM api = createInputFieldWithButton "gameName" "Game name" gameUpdateFunction
+createGameChangeNameDOM api = createInputFieldWithButton "game-name" "Game name" gameUpdateFunction
   where
     gameUpdateFunction =
-      withElem "gameNameField" $ \field -> do
+      withElem "game-name-field" $ \field -> do
         newName <- getValue field
         case newName of
           Just ""   -> return ()
@@ -78,10 +78,10 @@ createGameChangeNameDOM api = createInputFieldWithButton "gameName" "Game name" 
 -- |Contains an input field and a button. Is placed in the right sidebar
 createUpdateMaxNumberPlayersDOM :: LobbyAPI -> GameAPI-> Client ()
 createUpdateMaxNumberPlayersDOM api gapi =
-  createInputFieldWithButton "maxNumber" "Maximum number of players" maxNumberUpdateFunction
+  createInputFieldWithButton "max-number" "Maximum number of players" maxNumberUpdateFunction
   where
     maxNumberUpdateFunction =
-      withElem "maxNumberField" $ \field -> do
+      withElem "max-number-field" $ \field -> do
         newNumber <- getValue field
         case newNumber of
           Just ""   -> return ()
@@ -97,10 +97,10 @@ createUpdateMaxNumberPlayersDOM api gapi =
 -- |Creates an input field for setting the password of a game.
 -- |Contains an input field and a button. Is placed in right sidebar.
 createSetPasswordDOM :: LobbyAPI -> Client ()
-createSetPasswordDOM api = createInputFieldWithButton "setPassword" "Set password" setPasswordFunction
+createSetPasswordDOM api = createInputFieldWithButton "set-password" "Set password" setPasswordFunction
   where
     setPasswordFunction =
-      withElem "setPasswordField" $ \field -> do
+      withElem "set-password-field" $ \field -> do
         maybePassword <- getValue field
         case maybePassword of
           Nothing             -> return ()
@@ -129,7 +129,7 @@ addPlayerWithKickToPlayerlist api parent name = do
 -- |Adds DOM for a game
 addGame :: LobbyAPI -> GameAPI -> String -> Client ()
 addGame api gapi gameID = do
-  maybeGameListDiv <- elemById "gamesListTableBody"
+  maybeGameListDiv <- elemById "games-list-table-body"
   case maybeGameListDiv of
     Nothing -> return ()
     Just gameListDiv -> do
@@ -169,21 +169,21 @@ addGame api gapi gameID = do
 -- |Updates the list of players in a game on the client
 updatePlayerListGame :: LobbyAPI -> Client ()
 updatePlayerListGame api = do
-  playerDiv <- elemById "gamePlayerList"
+  playerDiv <- elemById "game-player-list"
   case playerDiv of
     Just parent -> do
       players <- onServer $ findPlayersInGame api
       clearChildren parent
       br <- newElem "br"
       text <- newTextElem "Players:"
-      addChildrenToParent "gamePlayerList" [text, br]
+      addChildrenToParent "game-player-list" [text, br]
       mapM_ (addPlayerWithKickToPlayerlist api parent) players
     Nothing     -> return ()
 
 -- |Updates the game header with the value at the server
 updateGameHeader :: LobbyAPI -> Client ()
 updateGameHeader api = do
-  maybeHeader <- elemById "gameHeader"
+  maybeHeader <- elemById "game-header"
   case maybeHeader of
     Nothing     -> return ()
     Just parent -> do

--- a/src/Views/Game.hs
+++ b/src/Views/Game.hs
@@ -142,13 +142,21 @@ addGame api gapi gameID = do
       appendChild gameListDiv gameDiv
 
       clickEventString gameName $ do
-        bool <- onServer $ joinGame api <.> gameID
-        if bool then do
-            deleteLobbyDOM
-            createGameDOM api gapi
+        hasPassword <- onServer $ isGamePasswordProtected api <.> gameID
+        if hasPassword then do
+          password <- prompt "Enter password"
+          joinGameClient password
         else
-          return ()
+          joinGameClient ""
       return ()
+  where
+    joinGameClient password = do
+      allowedToJoin <- onServer $ joinGame api <.> gameID <.> password
+      if allowedToJoin then do
+          deleteLobbyDOM
+          createGameDOM api gapi
+      else
+        return ()
 
 -- |Updates the list of players in a game on the client
 updatePlayerListGame :: LobbyAPI -> Client ()

--- a/src/Views/Game.hs
+++ b/src/Views/Game.hs
@@ -21,6 +21,7 @@ createGameDOM api gapi = do
 
   createGameChangeNameDOM api
   createUpdateMaxNumberPlayersDOM api gapi
+  createSetPasswordDOM api
 
   gameName <- onServer $ findGameName api
   players <- onServer $ findPlayersInGame api
@@ -90,6 +91,20 @@ createUpdateMaxNumberPlayersDOM api gapi =
                           | otherwise -> return ()
           Nothing   -> return ()
 
+-- |Creates an input field for setting the password of a game.
+-- |Contains an input field and a button. Is placed in right sidebar.
+createSetPasswordDOM :: LobbyAPI -> Client ()
+createSetPasswordDOM api = createInputFieldWithButton "setPassword" "Set password for this game" setPasswordFunction
+  where
+    setPasswordFunction =
+      withElem "setPasswordField" $ \field -> do
+        maybePassword <- getValue field
+        case maybePassword of
+          Nothing             -> return ()
+          Just ""             -> return ()
+          Just passwordString -> do
+            setProp field "value" ""
+            onServer $ setPassword api <.> passwordString
 
 -- |Convenience function for calling on the kick function.
 kickFunction :: Name -> LobbyAPI -> Client ()

--- a/src/Views/Game.hs
+++ b/src/Views/Game.hs
@@ -14,7 +14,7 @@ import GameAPI
 
 import Text.Read
 
-import Control.Monad
+import Control.Monad (when)
 
 -- |Creates the DOM for a 'LobbyGame' inside the lobby
 -- Useful since the Client is unaware of the specific 'LobbyGame' but can get the name and list with 'Name's of players from the server.

--- a/src/Views/Lobby.hs
+++ b/src/Views/Lobby.hs
@@ -24,32 +24,7 @@ import Views.Chat
 -- |Creates DOM for chaning nick name
 -- |Includes an input field and a button.
 createChangeNickNameDOM :: LobbyAPI -> Client ()
-createChangeNickNameDOM api = do
-  nickDiv <- createDiv [("id","nickNameDiv")]
-
-  nickNameText <- newTextElem "Change nick name"
-  nickNameField <- newElem "input" `with`
-    [
-      attr "type" =: "text",
-      attr "id" =: "nickNameField"
-    ]
-  nickNameButton <- newElem "button" `with`
-    [
-      attr "id" =: "nickNameBtn"
-    ]
-  nickNameBtnText <- newTextElem "Change"
-
-  appendChild nickNameButton nickNameBtnText
-  appendChild nickDiv nickNameText
-  appendChild nickDiv nickNameField
-  appendChild nickDiv nickNameButton
-  addChildrenToRightColumn [nickDiv]
-
-  onEvent nickNameField KeyPress $ \13 -> nickUpdateFunction
-
-  clickEventString "nickNameBtn" nickUpdateFunction
-  return ()
-
+createChangeNickNameDOM api = createInputFieldWithButton "nickName" "Nick name" nickUpdateFunction
   where
     nickUpdateFunction =
       withElem "nickNameField" $ \field -> do

--- a/src/Views/Lobby.hs
+++ b/src/Views/Lobby.hs
@@ -24,10 +24,10 @@ import Views.Chat
 -- |Creates DOM for chaning nick name
 -- |Includes an input field and a button.
 createChangeNickNameDOM :: LobbyAPI -> Client ()
-createChangeNickNameDOM api = createInputFieldWithButton "nickName" "Nick name" nickUpdateFunction
+createChangeNickNameDOM api = createInputFieldWithButton "nick-name" "Nick name" nickUpdateFunction
   where
     nickUpdateFunction =
-      withElem "nickNameField" $ \field -> do
+      withElem "nick-name-field" $ \field -> do
         newName <- getValue field
         case newName of
           Just ""   -> return ()
@@ -44,7 +44,7 @@ createLobbyDOM api gapi = do
 
   createGamebtn <- newElem "button" `with`
     [
-      prop "id" =: "createGamebtn"
+      prop "id" =: "create-game-btn"
     ]
   crGamebtnText <- newTextElem "Create new game"
 
@@ -61,12 +61,12 @@ createLobbyDOM api gapi = do
 
   playerList <- newElem "div" `with`
     [
-      prop "id" =: "playerList"
+      prop "id" =: "player-list"
     ]
 
   gamesListDiv <- newElem "div" `with`
     [
-      attr "id" =: "gamesList",
+      attr "id" =: "games-list",
       style "height" =: "500px",
       style "overflow" =: "auto"
     ]
@@ -79,7 +79,7 @@ createLobbyDOM api gapi = do
   thJoinText <- newTextElem ""
   tbody <- newElem "tbody" `with`
     [
-      prop "id" =: "gamesListTableBody"
+      prop "id" =: "games-list-table-body"
     ]
   setClass gameListTable "table" True
   setClass gameListTable "table-striped" True
@@ -105,7 +105,7 @@ createLobbyDOM api gapi = do
 -- |Creates a button for creating a 'LobbyGame'
 createGameBtn :: LobbyAPI -> GameAPI-> Client ()
 createGameBtn lapi gapi = do
-  clickEventString "createGamebtn" onCreateBtnMouseClick
+  clickEventString "create-game-btn" onCreateBtnMouseClick
   return ()
   where
     onCreateBtnMouseClick = do
@@ -114,10 +114,10 @@ createGameBtn lapi gapi = do
         Nothing          -> return ()
         Just gameUuid -> do
           switchToGameDOM gameUuid
-          clickEventString "startGameButton" $ do
+          clickEventString "start-game-button" $ do
               gameDiv <- newElem "div" `with`
                 [
-                  prop "id" =: "gameDiv"
+                  prop "id" =: "game-div"
                 ]
               names <- onServer (findPlayersInGame lapi)
               startGame gapi names gameDiv
@@ -131,7 +131,7 @@ createGameBtn lapi gapi = do
 updatePlayerList :: LobbyAPI -> Client ()
 updatePlayerList api = do
   players <- onServer $ getPlayerNameList api
-  playerDiv <- elemById "playerList"
+  playerDiv <- elemById "player-list"
 
   case playerDiv of
     Just parent -> do
@@ -154,7 +154,7 @@ addGameToDOM api gameName = do
   gameDiv <- newElem "div"
   gameEntry <- newElem "button" `with`
     [
-      prop "id" =: "gameName"
+      prop "id" =: "game-name"
     ]
   textElem <- newTextElem gameName
   appendChild gameEntry textElem
@@ -169,7 +169,7 @@ addGameToDOM api gameName = do
 -- |Updates the list of games that a player can join
 updateGamesList :: LobbyAPI -> GameAPI -> Client ()
 updateGamesList api gapi = do
-  gamesListDiv <- elemById "gamesListTableBody"
+  gamesListDiv <- elemById "games-list-table-body"
   case gamesListDiv of
     Just listDiv -> do
       clearChildren listDiv

--- a/src/Views/Lobby.hs
+++ b/src/Views/Lobby.hs
@@ -163,7 +163,7 @@ addGameToDOM api gameName = do
   appendChild documentBody gameDiv
 
   clickEventString gameName $ do
-    bool <- onServer $ joinGame api <.> gameName
+    bool <- onServer $ joinGame api <.> gameName <.> ""
     return ()
   return ()
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -14,4 +14,5 @@ extra-deps:
 - ghc-simple-0.3
 - data-embed-0.1.0.0
 - haste-compiler-0.5.4
+- pwstore-fast-2.4.4
 resolver: lts-5.2

--- a/test/Hastings/ServerUtilsTests.hs
+++ b/test/Hastings/ServerUtilsTests.hs
@@ -9,6 +9,7 @@ import Data.Word (Word64)
 import Control.Concurrent (Chan, newChan)
 import System.IO.Unsafe (unsafePerformIO)
 import Data.List (nub)
+import Data.ByteString.Char8 (empty)
 
 import LobbyTypes
 import Hastings.ServerUtils
@@ -38,7 +39,7 @@ instance Arbitrary GameData where
     playersNum <- arbitrary :: Gen Int
     let playersNum' = (abs.flip mod maxPlayers') playersNum -- No more players than max nuber
     clients <- sequence [ arbitrary | _ <- [1..playersNum']]
-    return $ GameData clients ("GameData " ++ show gameNr) maxPlayers'
+    return $ GameData clients ("GameData " ++ show gameNr) maxPlayers' empty
 
 
 -- Tests


### PR DESCRIPTION
Makes the games password protected if desired. All games start out as not protected and when a password has been set they can't be unset (has to have some password, can be fixed but I didn't think it relevant in this implementation). 

All passwords are sent to the server in clear text where they are hashed using [`Crypto.PasswordStore`](https://hackage.haskell.org/package/pwstore-fast-2.4.4/docs/Crypto-PasswordStore.html). This is because the library didn't work in Haste (got `Uncaught TypeError: Cannot read property 'a' of undefined`). It means that the communication has to rely on https to ensure that passwords can't be picked up by a malicious person.

The passwords are also in putted in clear text (no ***\* fields), can be fixed but didn't think it necessarily relevant to this implementation.

Fixes #68, fixes #9 (last part)
