### PR TITLE
Refactor/clean separation lobby server

### DIFF
--- a/Hastings.cabal
+++ b/Hastings.cabal
@@ -53,6 +53,7 @@ test-suite Hastings-test
   build-depends:
     base,
     Hastings,
+    haste-compiler,
     test-framework,
     test-framework-quickcheck2,
     QuickCheck

--- a/Hastings.cabal
+++ b/Hastings.cabal
@@ -16,13 +16,12 @@ cabal-version:       >=1.10
 library
   hs-source-dirs:      src
   build-depends:
-    base >= 4.7 && < 5,
-    QuickCheck
-  exposed-modules: Views.Chat Views.Lobby, Views.Common, Views.Game, LobbyTypes, Hastings.Utils, LobbyClient, LobbyAPI, GameAPI
+    base >= 4.7 && < 5
+  exposed-modules: Views.Chat, Views.Lobby, Views.Common, Views.Game, LobbyTypes, Hastings.Utils, LobbyClient, LobbyAPI, GameAPI
   if impl(haste)
     build-depends: haste-lib >= 0.5 && < 0.6
   else
-    exposed-modules: LobbyServer, Hastings.ServerUtils, Hastings.ServerUtilsTests
+    exposed-modules: LobbyServer, Hastings.ServerUtils
     build-depends:
       haste-compiler >= 0.5 && < 0.6,
       uuid,
@@ -51,12 +50,13 @@ test-suite Hastings-test
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test
   main-is:             Spec.hs
-  build-depends:       base
-                     , Hastings
-                     , test-framework
-                     , test-framework-quickcheck2
-                     , QuickCheck
-  other-modules:       Utils
+  build-depends:
+    base,
+    Hastings,
+    test-framework,
+    test-framework-quickcheck2,
+    QuickCheck
+  other-modules:       Utils, Hastings.ServerUtilsTests
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
 

--- a/Hastings.cabal
+++ b/Hastings.cabal
@@ -16,12 +16,13 @@ cabal-version:       >=1.10
 library
   hs-source-dirs:      src
   build-depends:
-    base >= 4.7 && < 5
+    base >= 4.7 && < 5,
+    QuickCheck
   exposed-modules: Views.Chat Views.Lobby, Views.Common, Views.Game, LobbyTypes, Hastings.Utils, LobbyClient, LobbyAPI, GameAPI
   if impl(haste)
     build-depends: haste-lib >= 0.5 && < 0.6
   else
-    exposed-modules: LobbyServer, Hastings.ServerUtils
+    exposed-modules: LobbyServer, Hastings.ServerUtils, Hastings.ServerUtilsTests
     build-depends:
       haste-compiler >= 0.5 && < 0.6,
       uuid,

--- a/Hastings.cabal
+++ b/Hastings.cabal
@@ -21,7 +21,7 @@ library
   if impl(haste)
     build-depends: haste-lib >= 0.5 && < 0.6
   else
-    exposed-modules: LobbyServer
+    exposed-modules: LobbyServer, Hastings.ServerUtils
     build-depends:
       haste-compiler >= 0.5 && < 0.6,
       uuid,

--- a/src/Hastings/ServerUtils.hs
+++ b/src/Hastings/ServerUtils.hs
@@ -27,3 +27,7 @@ deletePlayerFromGame clientName (gameID, gameData)  =
 addPlayerToGame :: ClientEntry -> String -> [LobbyGame] -> [LobbyGame]
 addPlayerToGame client gameID =
   updateListElem (\(gID, gameData) -> (gID, gameData {players = nub $ client : players gameData})) ((gameID ==) .fst)
+
+-- |Finds the 'LobbyGame' matching the first parameter and returns it
+findGameWithID :: String -> [LobbyGame] -> Maybe LobbyGame
+findGameWithID gid = find (\g -> fst g == gid)

--- a/src/Hastings/ServerUtils.hs
+++ b/src/Hastings/ServerUtils.hs
@@ -1,0 +1,29 @@
+module Hastings.ServerUtils where
+
+import LobbyTypes (LobbyGame, Name, ClientEntry, name, LobbyMessage, players, lobbyChannel)
+import Hastings.Utils (updateListElem)
+
+import qualified Control.Concurrent as CC (writeChan)
+import Data.List (find, nub)
+
+-- |Get's the uuid from a list of lobby games
+getUUIDFromGamesList :: [LobbyGame] -> [String]
+getUUIDFromGamesList = map fst
+
+-- |Finds the client with 'Name' from the list of 'ClientEntry'
+findClient :: Name -> [ClientEntry] -> Maybe ClientEntry
+findClient clientName = find ((clientName ==).name)
+
+-- |Maps over the clients and writes the message to their channel
+messageClients :: LobbyMessage -> [ClientEntry] -> IO ()
+messageClients m = mapM_ (\c -> CC.writeChan (lobbyChannel c) m)
+
+-- |Deletes the player with 'Name' from the game.
+deletePlayerFromGame :: Name -> LobbyGame -> LobbyGame
+deletePlayerFromGame clientName (gameID, gameData)  =
+  (gameID, gameData {players = filter ((clientName /=) . name) $ players gameData})
+
+-- |Adds a player to a lobby game with the game ID
+addPlayerToGame :: ClientEntry -> String -> [LobbyGame] -> [LobbyGame]
+addPlayerToGame client gameID =
+  updateListElem (\(gID, gameData) -> (gID, gameData {players = nub $ client : players gameData})) ((gameID ==) .fst)

--- a/src/Hastings/ServerUtils.hs
+++ b/src/Hastings/ServerUtils.hs
@@ -46,3 +46,7 @@ isOwnerOfGame sid gamesList =
   case findGameWithSid sid gamesList of
     Nothing         -> False
     Just (_, gData) -> sessionID (last $ players gData) == sid
+
+-- |Function that finds a 'ClientEntry' based on the 'SessionID'
+lookupClientEntry :: SessionID -> [ClientEntry] -> Maybe ClientEntry
+lookupClientEntry sid = find ((sid ==) . sessionID)

--- a/src/Hastings/ServerUtils.hs
+++ b/src/Hastings/ServerUtils.hs
@@ -1,3 +1,5 @@
+-- |Contains util functions for the module "LobbyServer".
+-- The functions are meant to be as pure as possible
 module Hastings.ServerUtils where
 
 import Haste.App (SessionID)

--- a/src/Hastings/ServerUtils.hs
+++ b/src/Hastings/ServerUtils.hs
@@ -26,6 +26,7 @@ deletePlayerFromGame clientName (gameID, gameData)  =
   (gameID, gameData {players = filter ((clientName /=) . name) $ players gameData})
 
 -- |Adds a player to a lobby game with the game ID
+-- Doesn't care if the max #players has been reached.
 addPlayerToGame :: ClientEntry -> String -> [LobbyGame] -> [LobbyGame]
 addPlayerToGame client gameID =
   updateListElem (\(gID, gameData) -> (gID, gameData {players = nub $ client : players gameData})) ((gameID ==) .fst)

--- a/src/Hastings/ServerUtils.hs
+++ b/src/Hastings/ServerUtils.hs
@@ -39,3 +39,10 @@ findGameWithSid :: SessionID -> [LobbyGame] -> Maybe LobbyGame
 findGameWithSid sid = find (\(_, gameData) -> sid `elem` sidsInGame gameData)
   where
     sidsInGame gameData = map sessionID $ players gameData
+
+-- |Returns if the current player is owner of the game it's in
+isOwnerOfGame :: SessionID -> [LobbyGame] -> Bool
+isOwnerOfGame sid gamesList =
+  case findGameWithSid sid gamesList of
+    Nothing         -> False
+    Just (_, gData) -> sessionID (last $ players gData) == sid

--- a/src/Hastings/ServerUtils.hs
+++ b/src/Hastings/ServerUtils.hs
@@ -1,6 +1,8 @@
 module Hastings.ServerUtils where
 
-import LobbyTypes (LobbyGame, Name, ClientEntry, name, LobbyMessage, players, lobbyChannel)
+import Haste.App (SessionID)
+
+import LobbyTypes (LobbyGame, Name, ClientEntry, name, LobbyMessage, players, lobbyChannel, sessionID)
 import Hastings.Utils (updateListElem)
 
 import qualified Control.Concurrent as CC (writeChan)
@@ -31,3 +33,9 @@ addPlayerToGame client gameID =
 -- |Finds the 'LobbyGame' matching the first parameter and returns it
 findGameWithID :: String -> [LobbyGame] -> Maybe LobbyGame
 findGameWithID gid = find (\g -> fst g == gid)
+
+-- |Finds the 'LobbyGame' that the current connection is in (or the first if there are multiple)
+findGameWithSid :: SessionID -> [LobbyGame] -> Maybe LobbyGame
+findGameWithSid sid = find (\(_, gameData) -> sid `elem` sidsInGame gameData)
+  where
+    sidsInGame gameData = map sessionID $ players gameData

--- a/src/Hastings/ServerUtilsTests.hs
+++ b/src/Hastings/ServerUtilsTests.hs
@@ -91,3 +91,16 @@ addPlayerToGamePropTemplate i list fun = fun gameID list' newList
     playersList list = players $ snd $ list !! i'
 
   -- other prop: check that it was not possible to join if max has been reached
+
+-- |Checks that findGameWithID finds the correct game
+prop_findGameWithID :: Int -> [LobbyGame] -> Property
+prop_findGameWithID i list = not (null list) ==>
+  case findGameWithID gameID list' of
+    Nothing         -> False
+    Just (guuid, _) -> gameID == guuid
+  where
+    i' = abs $ mod i (length list')
+    gameID = fst $ list' !! i'
+
+    list' = zipWith newLobbyGame list [0..]
+    newLobbyGame (_, gameData) i = (show i, gameData)

--- a/src/Hastings/ServerUtilsTests.hs
+++ b/src/Hastings/ServerUtilsTests.hs
@@ -1,0 +1,36 @@
+module Hastings.ServerUtilsTests where
+
+import Test.QuickCheck
+import Haste.App (SessionID, liftIO)
+import Data.Word (Word64)
+import Control.Concurrent (Chan, newChan)
+import System.IO.Unsafe (unsafePerformIO)
+
+import LobbyTypes
+
+
+
+
+-- Arbitrary instances for the Data types
+
+-- |Arbitrary ClientEntry
+-- Does not have any chat channels, and the LobbyChannel is created
+-- by unsafePerformIO (!)
+instance Arbitrary ClientEntry where
+  arbitrary = do
+    sessionIDWord64 <- arbitrary
+    clientNr <- arbitrary :: Gen Int
+    let chan = unsafePerformIO newChan
+    return $ ClientEntry sessionIDWord64 ("ClientEntry " ++ show clientNr) [] chan
+
+-- |Arbitrary GameData
+-- Limits the maxAmountOfPlayers to 26.
+instance Arbitrary GameData where
+  arbitrary = do
+    gameNr <- arbitrary :: Gen Int
+    maxPlayers <- arbitrary :: Gen Int
+    let maxPlayers' = 1 + (abs.flip mod 25) maxPlayers -- Reasonable amount of max players
+    playersNum <- arbitrary :: Gen Int
+    let playersNum' = (abs.flip mod maxPlayers') playersNum -- No more players than max nuber
+    clients <- sequence [ arbitrary | _ <- [1..playersNum']]
+    return $ GameData clients ("GameData " ++ show gameNr) maxPlayers'

--- a/src/Hastings/ServerUtilsTests.hs
+++ b/src/Hastings/ServerUtilsTests.hs
@@ -1,3 +1,6 @@
+-- |Tests functions from "Hastings.ServerUtils".
+-- Does not test simple functions such as those running a 'find'
+-- or simple 'map's.
 module Hastings.ServerUtilsTests where
 
 import Test.QuickCheck

--- a/src/Hastings/ServerUtilsTests.hs
+++ b/src/Hastings/ServerUtilsTests.hs
@@ -95,6 +95,7 @@ addPlayerToGamePropTemplate i list fun = fun gameID list' newList
   -- other prop: check that it was not possible to join if max has been reached
 
 -- |Checks that findGameWithID finds the correct game
+-- I.e. that the gameID is the same.
 prop_findGameWithID :: Int -> [LobbyGame] -> Property
 prop_findGameWithID i list = not (null list) ==>
   case findGameWithID gameID list' of
@@ -103,6 +104,28 @@ prop_findGameWithID i list = not (null list) ==>
   where
     i' = abs $ mod i (length list')
     gameID = fst $ list' !! i'
+
+    list' = zipWith newLobbyGame list [0..]
+    newLobbyGame (_, gameData) i = (show i, gameData)
+
+-- |Checks that this function always returns correct results
+-- I.e. given a SessionID that corresponds to the last player it returns 'True'
+-- and given any other SessionID it returns 'False'.
+-- The test fails if the SessionID's of the clients are not unique
+prop_isOwnerOfGame :: Int -- ^This 'Int' correseponds to which LobbyGame to choose
+  -> Int -- ^This 'Int' corresponds to which player to choose
+  -> [LobbyGame] -- ^The list of 'LobbyGame's to test. Is modified to make sure gameID is unique
+  -> Property
+prop_isOwnerOfGame i j list = not (null list) && not (null playersList)==>
+  case isOwnerOfGame sid list' of
+    False -> j' /= (length playersList - 1)
+    True  -> j' == (length playersList - 1)
+  where
+    i' = abs $ mod i (length list')
+    j' = abs $ mod j (length playersList)
+    sid = sessionID $ playersList !! j'
+
+    playersList = players $ snd $ list' !! i'
 
     list' = zipWith newLobbyGame list [0..]
     newLobbyGame (_, gameData) i = (show i, gameData)

--- a/src/Hastings/ServerUtilsTests.hs
+++ b/src/Hastings/ServerUtilsTests.hs
@@ -72,7 +72,9 @@ prop_addPlayerToGame_unique i list = not (null list) ==>
   where
     addIfChanged ((guuid,og), (_,ng)) | length (players og) == length (players ng) = (+ 0)
                                       | otherwise                                  = (+ 1)
-
+-- |Template for tests with addPlayerToGame
+-- Requires a function that wants the GameID (of the game that was changed), and two lists of games
+-- , one unchanged and one where a player has been added.
 addPlayerToGamePropTemplate :: Int -> [LobbyGame] -> (String -> [LobbyGame] -> [LobbyGame] -> Bool) -> Bool
 addPlayerToGamePropTemplate i list fun = fun gameID list' newList
   where

--- a/src/Hastings/ServerUtilsTests.hs
+++ b/src/Hastings/ServerUtilsTests.hs
@@ -7,9 +7,7 @@ import Control.Concurrent (Chan, newChan)
 import System.IO.Unsafe (unsafePerformIO)
 
 import LobbyTypes
-
-
-
+import Hastings.ServerUtils
 
 -- Arbitrary instances for the Data types
 

--- a/src/Hastings/ServerUtilsTests.hs
+++ b/src/Hastings/ServerUtilsTests.hs
@@ -20,7 +20,7 @@ import Hastings.ServerUtils
 -- by unsafePerformIO (!)
 instance Arbitrary ClientEntry where
   arbitrary = do
-    sessionIDWord64 <- arbitrary
+    sessionIDWord64 <- elements [1..18446] -- SessionID should be unique
     clientNr <- arbitrary :: Gen Int
     let chan = unsafePerformIO newChan
     return $ ClientEntry sessionIDWord64 ("ClientEntry " ++ show clientNr) [] chan
@@ -57,7 +57,6 @@ prop_deletePlayerFromGame_length i g@(_, gameData) = not (null (players gameData
 -- |Property that checks that only the correct one has changed, and all others have the same length.
 -- Runs nub on the list of players since sessionID's are meant to be unique
 -- Also goes through each LobbyGame to make sure the GameID is unique.
--- Will fail if `18446744073709551615` is the sessionID of one of the clients.
 prop_addPlayerToGame_length :: Int -> [LobbyGame] -> Property
 prop_addPlayerToGame_length i list = not (null list) ==>
   addPlayerToGamePropTemplate i list fun

--- a/src/Hastings/ServerUtilsTests.hs
+++ b/src/Hastings/ServerUtilsTests.hs
@@ -32,3 +32,20 @@ instance Arbitrary GameData where
     let playersNum' = (abs.flip mod maxPlayers') playersNum -- No more players than max nuber
     clients <- sequence [ arbitrary | _ <- [1..playersNum']]
     return $ GameData clients ("GameData " ++ show gameNr) maxPlayers'
+
+
+-- Tests
+
+prop_getUUIDFromGamesList :: [LobbyGame] -> Property
+prop_getUUIDFromGamesList list = not (null list) ==>
+  [fst x | x <- list ] == getUUIDFromGamesList list
+
+prop_deletePlayerFromGame :: Int -> LobbyGame -> Property
+prop_deletePlayerFromGame i g@(_, gameData) = not (null (players gameData)) ==>
+  length (players gameData) - 1 == length (players newGameData)
+  where
+    (_, newGameData) = deletePlayerFromGame playerName g
+
+    i' =  abs $ mod i (length $ players gameData)
+    player = (players gameData) !! i'
+    playerName = name player

--- a/src/LobbyServer.hs
+++ b/src/LobbyServer.hs
@@ -147,15 +147,6 @@ findGameNameWithSid remoteGames = do
     Just (_, gameData) -> return $ gameName gameData
     Nothing            -> return ""
 
--- |Finds the name of the players of a game given it's identifier
-playerNamesInGameWithID :: Server GamesList -> String -> Server [String]
-playerNamesInGameWithID remoteGameList gid = do
-  mVarGamesList <- remoteGameList
-  maybeGame <- liftIO $ findGameWithID gid mVarGamesList
-  case maybeGame of
-    Just (gid, gameData)   -> return $ map name $ players gameData
-    Nothing                -> return []
-
 -- |Finds the name of the players of the game the current client is in
 playerNamesInGameWithSid :: Server GamesList -> Server [String]
 playerNamesInGameWithSid remoteGameList = do

--- a/src/LobbyServer.hs
+++ b/src/LobbyServer.hs
@@ -263,9 +263,8 @@ changeMaxNumberOfPlayers :: Server GamesList -> Int -> Server ()
 changeMaxNumberOfPlayers remoteGames newMax = do
   mVarGamesList <- remoteGames
   gamesList <- liftIO $ CC.readMVar mVarGamesList
-  isOwnerOfGame <- isOwnerOfGame remoteGames
   sid <- getSessionID
-  if isOwnerOfGame then do
+  if isOwnerOfGame sid gamesList then do
     case findGameWithSid sid gamesList of
       Nothing   -> return ()
       Just game ->
@@ -278,13 +277,11 @@ changeMaxNumberOfPlayers remoteGames newMax = do
     return ()
 
 -- |Returns if the current player is owner of the game it's in
-isOwnerOfGame :: Server GamesList -> Server Bool
-isOwnerOfGame remoteGames = do
+remoteIsOwnerOfGame :: Server GamesList -> Server Bool
+remoteIsOwnerOfGame remoteGames = do
   gamesList <- remoteGames >>= liftIO . CC.readMVar
   sid <- getSessionID
-  case findGameWithSid sid gamesList of
-    Nothing         -> return False
-    Just (_, gData) -> return $ sessionID (last $ players gData) == sid
+  return $ isOwnerOfGame sid gamesList
 
 -- |Called by client to join a chat
 joinChat :: Server ConcurrentClientList -> Server ConcurrentChatList -> String -> Server ()

--- a/src/LobbyServer.hs
+++ b/src/LobbyServer.hs
@@ -120,15 +120,14 @@ playerJoinGame remoteClientList remoteGameList gameID = do
   case maybeGame of
     Nothing           -> return False
     Just (_,gameData) ->
-      if maxAmountOfPlayers gameData > length (players gameData) then do
-          case lookupClientEntry sid clientList of
-            Nothing     -> liftIO $ putStrLn "playerJoinGame: Client not registered"
-            Just player -> liftIO $ CC.modifyMVar_ gameList $
+      case (maxAmountOfPlayers gameData > length (players gameData), lookupClientEntry sid clientList) of
+        (True, Just player) -> do
+          liftIO $ do
+            CC.modifyMVar_ gameList $
               \gList -> return $ addPlayerToGame player gameID gList
-
-          liftIO $ messageClients PlayerJoinedGame (players gameData)
+            messageClients PlayerJoinedGame (players gameData)
           return True
-      else return False
+        _     -> return False
 
 -- |Finds the name of a game given it's identifier
 findGameNameWithID :: Server GamesList -> String -> Server String

--- a/src/LobbyServer.hs
+++ b/src/LobbyServer.hs
@@ -195,24 +195,6 @@ changeNickName remoteClientList remoteGames newName = do
   where
     updateNick sid = updateListElem (\c -> c {name = newName}) (\c -> sid == sessionID c)
 
--- |Change the name of a 'LobbyGame' given the game's ID
-changeGameNameWithID :: Server GamesList -> Server ConcurrentClientList -> String -> Name -> Server ()
-changeGameNameWithID remoteGames remoteClients uuid newName = do
-  mVarGamesList <- remoteGames
-  mVarClientList <- remoteClients
-  gamesList <- liftIO $ CC.readMVar mVarGamesList
-  case findGameWithID uuid gamesList of
-    Nothing                -> return ()
-    Just game@(_,gameData) ->
-      liftIO $ CC.modifyMVar_ mVarGamesList $ \games ->
-        return $ updateListElem
-          (\(guuid, gData) -> (guuid, gData {gameName = newName}))
-          (== game)
-          games
-  liftIO $ do
-    clientsList <- CC.readMVar mVarClientList
-    messageClients GameNameChange clientsList
-
 -- |Change the name of a 'LobbyGame' that the connected client is in
 changeGameNameWithSid :: Server GamesList -> Server ConcurrentClientList -> Name -> Server ()
 changeGameNameWithSid remoteGames remoteClients newName = do

--- a/src/LobbyServer.hs
+++ b/src/LobbyServer.hs
@@ -127,7 +127,7 @@ playerJoinGame remoteClientList remoteGameList gameID = do
               \gList -> return $ addPlayerToGame player gameID gList
             messageClients PlayerJoinedGame (players gameData)
           return True
-        _     -> return False
+        _                   -> return False
 
 -- |Finds the name of a game given it's identifier
 findGameNameWithID :: Server GamesList -> String -> Server String
@@ -328,5 +328,4 @@ getClientName remoteClientList = do
   sid <- getSessionID
   concurrentClientList <- remoteClientList
   clientList <- liftIO $ CC.readMVar concurrentClientList
-  let client = find ((sid ==) . sessionID) clientList
-  return $ name $ fromJust client
+  return $ name $ fromJust $ lookupClientEntry sid clientList

--- a/src/LobbyServer.hs
+++ b/src/LobbyServer.hs
@@ -162,18 +162,6 @@ getConnectedPlayerNames remoteClientList = do
   clientList <- liftIO $ CC.readMVar concurrentClientList
   return $ map name clientList
 
--- | Kicks the player with 'Name' from the game with id String
--- Currently does not notify the kicked person it has been kicked
--- Implement this if the method is used in the future.
-kickPlayerWithGameID :: Server GamesList -> String -> Name -> Server ()
-kickPlayerWithGameID remoteGames gameID clientName = do
-  mVarGamesList <- remoteGames
-  liftIO $ CC.modifyMVar_ mVarGamesList $ \lst -> do
-    let (h,t) = break ((gameID ==) . fst) lst
-    case t of
-      (game : gt)    -> return $ h ++ (deletePlayerFromGame clientName game) : gt
-      _              -> return $ h ++ t
-
 -- |Kicks the player with 'Name' from the game that the current client is in.
 kickPlayerWithSid :: Server GamesList -> Name -> Server ()
 kickPlayerWithSid remoteGames clientName = do

--- a/src/LobbyTypes.hs
+++ b/src/LobbyTypes.hs
@@ -86,9 +86,6 @@ instance Binary ChatMessage where
 -- |A list of all the chats in the lobby.
 type ConcurrentChatList = CC.MVar [Chat]
 
-lookupClientEntry :: SessionID -> [ClientEntry] -> Maybe ClientEntry
-lookupClientEntry sid = find ((sid ==) . sessionID)
-
 -- |LobbyMessage is a message to a client idicating some udate to the state that the cliet has to adapt to.
 data LobbyMessage = NickChange | GameNameChange | KickedFromGame | GameAdded | ClientJoined
       | ClientLeft | PlayerJoinedGame | LobbyError {lobbyErrorMessage :: String}

--- a/src/LobbyTypes.hs
+++ b/src/LobbyTypes.hs
@@ -13,6 +13,10 @@ data ClientEntry = ClientEntry {sessionID    :: SessionID
                                ,name         :: Name
                                ,chats        :: [Chat]
                                ,lobbyChannel :: CC.Chan LobbyMessage}
+
+instance Show ClientEntry where
+  show c = "sessionID: " ++ show (sessionID c) ++ " name: " ++ show (name c)
+
 instance Eq ClientEntry where
   c1 == c2 = sessionID c1 == sessionID c2
   c1 /= c2 = sessionID c1 == sessionID c2
@@ -29,7 +33,7 @@ type LobbyGame = (String, GameData)
 data GameData = GameData {players            :: [ClientEntry],
                           gameName           :: Name,
                           maxAmountOfPlayers :: Int}
-  deriving (Eq)
+  deriving (Eq, Show)
 
 -- |A list of all the 'LobbyGame's that have been started inside the Lobby.
 type GamesList = CC.MVar [LobbyGame]

--- a/stack.yaml
+++ b/stack.yaml
@@ -14,4 +14,5 @@ extra-deps:
 - ghc-simple-0.3
 - data-embed-0.1.0.0
 - haste-compiler-0.5.4
+- QuickCheck-2.8.2
 resolver: lts-5.2

--- a/test/Hastings/ServerUtilsTests.hs
+++ b/test/Hastings/ServerUtilsTests.hs
@@ -127,9 +127,9 @@ prop_isOwnerOfGame :: Int -- ^This 'Int' correseponds to which LobbyGame to choo
   -> [LobbyGame] -- ^The list of 'LobbyGame's to test. Is modified to make sure gameID is unique
   -> Property
 prop_isOwnerOfGame i j list = not (null list) && not (null playersList)==>
-  case isOwnerOfGame sid list' of
-    False -> j' /= (length playersList - 1)
-    True  -> j' == (length playersList - 1)
+  if isOwnerOfGame sid list'
+    then j' == (length playersList - 1)
+    else j' /= (length playersList - 1)
   where
     i' = abs $ mod i (length list')
     j' = abs $ mod j (length playersList)

--- a/test/Hastings/ServerUtilsTests.hs
+++ b/test/Hastings/ServerUtilsTests.hs
@@ -43,10 +43,12 @@ instance Arbitrary GameData where
 
 -- Tests
 
+-- |Property that checks that the UUIDs received are the correct ones
 prop_getUUIDFromGamesList :: [LobbyGame] -> Property
 prop_getUUIDFromGamesList list = not (null list) ==>
   [fst x | x <- list ] == getUUIDFromGamesList list
 
+-- |Property that checks that a player is deleted
 prop_deletePlayerFromGame_length :: Int -> LobbyGame -> Property
 prop_deletePlayerFromGame_length i g@(_, gameData) = not (null (players gameData)) ==>
   length (players gameData) - 1 == length (players newGameData)
@@ -80,7 +82,13 @@ prop_addPlayerToGame_unique i list = not (null list) ==>
 -- |Template for tests with addPlayerToGame
 -- Requires a function that wants the GameID (of the game that was changed), and two lists of games
 -- , one unchanged and one where a player has been added.
-addPlayerToGamePropTemplate :: Int -> [LobbyGame] -> (String -> [LobbyGame] -> [LobbyGame] -> Bool) -> Bool
+addPlayerToGamePropTemplate :: Int -- ^ This 'Int' corresponds to which 'LobbyGame' to choose
+  -> [LobbyGame] -- ^The list to test
+  -> ( String -- ^GameID of the choosen game
+    -> [LobbyGame] -- ^The originial list of 'LobbyGame's
+    -> [LobbyGame] -- ^The list of 'LobbyGame's where a player has been adde
+    -> Bool) -- ^The function that determines if the test succeeds
+  -> Bool
 addPlayerToGamePropTemplate i list fun = fun gameID list' newList
   where
     list' = zipWith newLobbyGame list [0..]

--- a/test/Hastings/ServerUtilsTests.hs
+++ b/test/Hastings/ServerUtilsTests.hs
@@ -14,7 +14,7 @@ import LobbyTypes
 import Hastings.ServerUtils
 
 -- To run tests in ghci
--- :l ../test/Hastings/ServerUtilsTests.hs Hastings/ServerUtils.hs Hastings/Utils.hs LobbyTypes.hs 
+-- :l test/Hastings/ServerUtilsTests.hs src/Hastings/ServerUtils.hs src/Hastings/Utils.hs src/LobbyTypes.hs
 
 -- Arbitrary instances for the Data types
 

--- a/test/Hastings/ServerUtilsTests.hs
+++ b/test/Hastings/ServerUtilsTests.hs
@@ -13,6 +13,9 @@ import Data.List (nub)
 import LobbyTypes
 import Hastings.ServerUtils
 
+-- To run tests in ghci
+-- :l ../test/Hastings/ServerUtilsTests.hs Hastings/ServerUtils.hs Hastings/Utils.hs LobbyTypes.hs 
+
 -- Arbitrary instances for the Data types
 
 -- |Arbitrary ClientEntry
@@ -20,7 +23,7 @@ import Hastings.ServerUtils
 -- by unsafePerformIO (!)
 instance Arbitrary ClientEntry where
   arbitrary = do
-    sessionIDWord64 <- elements [1..18446] -- SessionID should be unique
+    sessionIDWord64 <- elements [1..184467] -- SessionID should be unique, increasing this number will make some props very slow
     clientNr <- arbitrary :: Gen Int
     let chan = unsafePerformIO newChan
     return $ ClientEntry sessionIDWord64 ("ClientEntry " ++ show clientNr) [] chan

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -2,6 +2,7 @@ import Test.Framework (defaultMain, testGroup)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
 
 import Utils
+import Hastings.ServerUtilsTests
 
 main = defaultMain tests
 
@@ -13,5 +14,22 @@ tests = [
     testGroup "UpdateListElem" [
       testProperty "Test that exactly one element is updated and that element is updated correctly" prop_updateListElem_correctUpdate,
       testProperty "Test that the list is the same order as before" prop_updateLookup_correctUpdate
+    ],
+    testGroup "getUUIDFromGamesList" [
+      testProperty "Tests that the uuids received are the correct ones" prop_getUUIDFromGamesList
+    ],
+    testGroup "deletePlayerFromGame" [
+      testProperty "Checks that a player has been deleted after the function is done" prop_deletePlayerFromGame_length
+    ],
+    testGroup "addPlayerToGame" [
+      testProperty "Checks that only a single player has been added" prop_addPlayerToGame_length,
+      testProperty "Checks that only one LobbyGame has been changed" prop_addPlayerToGame_unique
+    ],
+    testGroup "findGameWithID" [
+      testProperty "Check that the correct game has been found" prop_findGameWithID
+    ],
+    testGroup "isOwnerOfGame" [
+      testProperty "Checks that the function returns the correct result (True if the client is last in the players list, False otherwise)" prop_isOwnerOfGame
     ]
+
   ]


### PR DESCRIPTION
# Refactor

All pure functions that were previously in `LobbyServer` has been moved to `Hastings.LobbyServerUtils`. Some of the functions have been modified to not perform monadic actions as that could be done in a higher level function. 

Removed some unused functions that were left after changing from accessing a game with it's `GameUUID` to the players `SessionID`. 
# Tests

Wrote tests that document the methods in `Hastings.LobbyServerUtils`. Added these tests in `Spec.hs`.

The travis tests fail, but that is because of #72 .

Resolves #58 
