### PR TITLE
Bug/delete only one player from game

### DIFF
--- a/src/LobbyAPI.hs
+++ b/src/LobbyAPI.hs
@@ -27,7 +27,8 @@ data LobbyAPI = LobbyAPI
   , findGameName :: Remote (Server String)
   , getPlayerNameList :: Remote (Server [String])
     -- |Kicks a player frrom a game.
-  , kickPlayer :: Remote (Name -> Server ())
+  , kickPlayer :: Remote ( Int  -- ^The index of the player to kick
+                         -> Server ())
     -- |Changes the nickname of the active player
   , changeNickName :: Remote (Name -> Server ())
     -- |Change the name of the game to the new name

--- a/src/LobbyServer.hs
+++ b/src/LobbyServer.hs
@@ -55,7 +55,7 @@ connect remoteClientList remoteChats name = do
 -- |Disconnect client from server.
 disconnect :: LobbyState -> SessionID -> Server()
 disconnect (clientList, games, chats) sid = do
-  disconnectPlayerFromGame games clientList sid
+  disconnectPlayerFromGame games sid
   disconnectPlayerFromLobby clientList sid
 
   mVarClients <- clientList
@@ -71,18 +71,15 @@ disconnectPlayerFromLobby remoteClientList sid = do
     return $ filter ((sid /=) . sessionID) cs
 
 -- |Removes a player that has disconnected from all games
-disconnectPlayerFromGame :: Server GamesList -> Server ConcurrentClientList -> SessionID -> Server ()
-disconnectPlayerFromGame remoteGames remoteClientList sid = do
+disconnectPlayerFromGame :: Server GamesList -> SessionID -> Server ()
+disconnectPlayerFromGame remoteGames sid = do
   mVarGames <- remoteGames
-  concurrentClientList <- remoteClientList
-  clientList <- liftIO $ CC.readMVar concurrentClientList
-  case lookupClientEntry sid clientList of
-    Nothing -> return ()
-    Just clientEntry -> liftIO $ CC.modifyMVar_ mVarGames $ \games -> mapM removePlayer games
-      where
-        removePlayer (uuid, gameData) =
-          let newClientList = filter ((name clientEntry /=) . name) $ players gameData in
-          return (uuid, gameData {players = newClientList})
+  liftIO $ CC.modifyMVar_ mVarGames $ \games -> mapM removePlayer games
+
+  where
+    removePlayer (uuid, gameData) =
+      let newClientList = filter ((sid /=) . sessionID) $ players gameData in
+      return (uuid, gameData {players = newClientList})
 
 -- |Creates a new game on the server. The 'Int' represents the max number of players.
 createGame :: Server GamesList -> Server ConcurrentClientList -> Int -> Server (Maybe String)

--- a/src/LobbyServer.hs
+++ b/src/LobbyServer.hs
@@ -191,10 +191,14 @@ getConnectedPlayerNames remoteClientList = do
   clientList <- liftIO $ CC.readMVar concurrentClientList
   return $ map name clientList
 
--- | Kicks the player with 'Int' from the game with id String
+-- | Kicks the player with index 'Int' from the list of players in the
+-- game with id String
 -- Currently does not notify the kicked person it has been kicked
 -- Implement this if the method is used in the future.
-kickPlayerWithGameID :: Server GamesList -> String -> Int -> Server ()
+kickPlayerWithGameID :: Server GamesList
+                     -> String  -- ^The UUID of the game
+                     -> Int     -- ^The index in the list of players of the player to kick
+                     -> Server ()
 kickPlayerWithGameID remoteGames gameID clientIndex = do
   mVarGamesList <- remoteGames
   liftIO $ CC.modifyMVar_ mVarGamesList $ \lst -> do
@@ -203,8 +207,11 @@ kickPlayerWithGameID remoteGames gameID clientIndex = do
       (game : gt)    -> return $ h ++ (deletePlayerFromGame clientIndex game) : gt
       _              -> return $ h ++ t
 
--- |Kicks the player with 'Int' from the game that the current client is in.
-kickPlayerWithSid :: Server GamesList -> Int -> Server ()
+-- |Kicks the player with index 'Int' from the list of players in
+-- the game that the current client is in.
+kickPlayerWithSid :: Server GamesList
+                  -> Int  -- ^The index in the list of players of the player to kick
+                  -> Server ()
 kickPlayerWithSid remoteGames clientIndex = do
   mVarGamesList <- remoteGames
   maybeGame <- findGameWithSid mVarGamesList

--- a/src/LobbyServer.hs
+++ b/src/LobbyServer.hs
@@ -217,7 +217,7 @@ kickPlayerWithSid remoteGames clientIndex = do
   maybeGame <- findGameWithSid mVarGamesList
   case maybeGame of
     Nothing   -> return ()
-    Just game@(_,gameData) -> do
+    Just game@(_,gameData) ->
       liftIO $ do
         CC.modifyMVar_ mVarGamesList $ \games ->
           return $ updateListElem (deletePlayerFromGame clientIndex) (== game) games

--- a/src/Views/Game.hs
+++ b/src/Views/Game.hs
@@ -52,7 +52,7 @@ createGameDOM api gapi = do
   appendChild list listhead
   appendChild list br
 
-  mapM_ (addPlayerWithKickToPlayerlist api list) players
+  addPlayersToPlayerList api list players
 
   addChildrenToParent' parentDiv [header, list, createStartGameBtn]
   addChildrenToCenterColumn [parentDiv]
@@ -140,25 +140,25 @@ createUpdateMaxNumberPlayersDOM api gapi = do
                           | otherwise -> return ()
           Nothing   -> return ()
 
--- |Convenience function for calling on the kick function.
-kickFunction :: Name -> LobbyAPI -> Client ()
-kickFunction name api = onServer $ kickPlayer api <.> name
-
--- |Adds the playername and a button to kick them followed by a <br> tag to the given parent.
-addPlayerWithKickToPlayerlist :: LobbyAPI -> Elem -> String -> Client ()
-addPlayerWithKickToPlayerlist api parent name = do
-  textElem <- newTextElem name
-  br <- newElem "br"
-  kickBtn <- newElem "button" `with`
-    [
-      attr "class" =: "btn btn-default"
-    ]
-  kick <- newTextElem "kick"
-  clickEventElem kickBtn $ kickFunction name api
-  appendChild kickBtn kick
-  appendChild parent textElem
-  appendChild parent kickBtn
-  appendChild parent br
+-- |Adds the list of 'Name' to the list of players with
+-- Also adds a kick button if the current player is owner of the game
+addPlayersToPlayerList :: LobbyAPI -> Elem -> [Name] -> Client ()
+addPlayersToPlayerList api parent = addPlayersToPlayerList' 0
+  where
+    addPlayersToPlayerList' :: Int -> [Name] -> Client ()
+    addPlayersToPlayerList' i []     = return ()
+    addPlayersToPlayerList' i (name:names) = do
+      textElem <- newTextElem name
+      br <- newElem "br"
+      kickBtn <- newElem "button" `with`
+        [
+          attr "class" =: "btn btn-default"
+        ]
+      kick <- newTextElem "kick"
+      clickEventElem kickBtn $ onServer $ kickPlayer api <.> i
+      appendChild kickBtn kick
+      addChildrenToParent' parent [textElem, kickBtn, br]
+      addPlayersToPlayerList' (i+1) names
 
 -- |Adds DOM for a game
 addGame :: LobbyAPI -> GameAPI -> String -> Client ()
@@ -204,7 +204,7 @@ updatePlayerListGame api = do
       br <- newElem "br"
       text <- newTextElem "Players:"
       addChildrenToParent "gamePlayerList" [text, br]
-      mapM_ (addPlayerWithKickToPlayerlist api parent) players
+      addPlayersToPlayerList api parent players
     Nothing     -> return ()
 
 -- |Updates the game header with the value at the server


### PR DESCRIPTION
Makes sure that when kicking a player and when disconnecting that the server does not remove the wrong clients. 

Disconnecting now checks the SessionID if the player should be removed.

Kicking now receives an index of the player to kick (ugly, but I couldn't figure out any better way to do this).
