### PR TITLE
Feature/persistent storage

### DIFF
--- a/Hastings.cabal
+++ b/Hastings.cabal
@@ -21,7 +21,7 @@ library
   if impl(haste)
     build-depends: haste-lib >= 0.5 && < 0.6
   else
-    exposed-modules: LobbyServer, Hastings.Database.Database, Hastings.Database.Fields
+    exposed-modules: LobbyServer, Hastings.Database.Common, Hastings.Database.Fields
     build-depends:
       haste-compiler >= 0.5 && < 0.6,
       uuid,

--- a/Hastings.cabal
+++ b/Hastings.cabal
@@ -30,8 +30,7 @@ library
       persistent-mysql,
       persistent-template,
       esqueleto,
-      monad-logger,
-      transformers
+      monad-logger
   --  build-depends: containers
   default-language:    Haskell2010
 

--- a/Hastings.cabal
+++ b/Hastings.cabal
@@ -21,7 +21,7 @@ library
   if impl(haste)
     build-depends: haste-lib >= 0.5 && < 0.6
   else
-    exposed-modules: LobbyServer, Hastings.Database.Database
+    exposed-modules: LobbyServer, Hastings.Database.Database, Hastings.Database.Fields
     build-depends:
       haste-compiler >= 0.5 && < 0.6,
       uuid,

--- a/Hastings.cabal
+++ b/Hastings.cabal
@@ -21,11 +21,17 @@ library
   if impl(haste)
     build-depends: haste-lib >= 0.5 && < 0.6
   else
-    exposed-modules: LobbyServer
+    exposed-modules: LobbyServer, Hastings.Database.Database
     build-depends:
       haste-compiler >= 0.5 && < 0.6,
       uuid,
-      random
+      random,
+      persistent,
+      persistent-mysql,
+      persistent-template,
+      esqueleto,
+      monad-logger,
+      transformers
   --  build-depends: containers
   default-language:    Haskell2010
 

--- a/Hastings.cabal
+++ b/Hastings.cabal
@@ -21,7 +21,7 @@ library
   if impl(haste)
     build-depends: haste-lib >= 0.5 && < 0.6
   else
-    exposed-modules: LobbyServer, Hastings.ServerUtils, Hastings.Database.Common, Hastings.Database.Fields
+    exposed-modules: LobbyServer, Hastings.ServerUtils, Hastings.Database.Common, Hastings.Database.Fields, Hastings.Database.Player
     build-depends:
       haste-compiler >= 0.5 && < 0.6,
       uuid,

--- a/README.md
+++ b/README.md
@@ -32,3 +32,17 @@ stack exec -- Hastings-exe --embed dist/build/Hastings-exe/Hastings-exe --force
 stack exec Hastings-exe
 ```
 
+#### Database
+This application uses a MySQL database to store some of its data.
+The development version connects to the database with this connection information by default:
+```
+Host = "localhost",
+Port = 3306,
+User = "root",
+Password = "",
+Database = "hastings"
+```
+
+The schema hastings must be created manually before running the application for the first time, to do so execute this query on your database.
+```CREATE SCHEMA 'hastings'; ```
+

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -19,9 +19,11 @@ import GameAPI
 import LobbyClient
 #define disconnect(x) (\_ -> return ())
 #define migrateDatabase (return ())
+#define clearOnlinePlayers (return ())
 #else
 import LobbyServer
 import Hastings.Database.Common (migrateDatabase)
+import Hastings.Database.Player (clearOnlinePlayers)
 #define clientMain (\_ _ -> return ())
 #endif
 
@@ -34,6 +36,7 @@ main = runStandaloneApp $ do
 
   let serverState = (playersList, gamesList, chatList)
   liftServerIO $ migrateDatabase
+  liftServerIO $ clearOnlinePlayers
 
   onSessionEnd $ disconnect(serverState)
   api <- newLobbyAPI (playersList, gamesList, chatList)

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -18,8 +18,10 @@ import GameAPI
 #ifdef __HASTE__
 import LobbyClient
 #define disconnect(x) (\_ -> return ())
+#define migrateDatabase (return ())
 #else
 import LobbyServer
+import Hastings.Database.Common (migrateDatabase)
 #define clientMain (\_ _ -> return ())
 #endif
 
@@ -31,6 +33,7 @@ main = runStandaloneApp $ do
   chatList <- liftServerIO $ CC.newMVar []
 
   let serverState = (playersList, gamesList, chatList)
+  liftServerIO $ migrateDatabase
 
   onSessionEnd $ disconnect(serverState)
   api <- newLobbyAPI (playersList, gamesList, chatList)

--- a/src/Hastings/Database/Common.hs
+++ b/src/Hastings/Database/Common.hs
@@ -1,13 +1,9 @@
 module Hastings.Database.Common
    where
 
-
-import qualified Database.Persist
 import qualified Database.Persist.MySQL as MySQL
 import Database.Esqueleto
 import Control.Monad.Logger
-import Control.Monad.IO.Class
-import Control.Monad.Trans.Reader
 
 import Hastings.Database.Fields
 

--- a/src/Hastings/Database/Common.hs
+++ b/src/Hastings/Database/Common.hs
@@ -1,0 +1,24 @@
+module Hastings.Database.Common
+   where
+
+
+import qualified Database.Persist
+import qualified Database.Persist.MySQL as MySQL
+import Database.Esqueleto
+import Control.Monad.Logger
+import Control.Monad.IO.Class
+import Control.Monad.Trans.Reader
+
+import Hastings.Database.Fields
+
+-- |Run database migration, creating all relevant tables.
+migrateDatabase :: IO ()
+migrateDatabase = runDB $ runMigration migrateAll
+
+-- |Helper function that should be called before running a query on the database.
+--
+-- @
+-- saveCar = runDB $ insert $ Car \"Volvo\"
+-- @
+runDB :: SqlPersistT (NoLoggingT IO) a -> IO a
+runDB = runNoLoggingT . MySQL.withMySQLConn MySQL.defaultConnectInfo . runSqlConn

--- a/src/Hastings/Database/Common.hs
+++ b/src/Hastings/Database/Common.hs
@@ -13,7 +13,15 @@ migrateDatabase :: IO ()
 migrateDatabase = runDB $ runMigration migrateAll
 
 -- |Helper function that should be called before running a query on the database.
+--  It's primary purpose is running the proper prerequisites to be able to excecute an SQL query on the database.
+--  It connects to a database with the following connection information
+-- * Server on localhost
+-- * User root
+-- * No password
+-- * Database test
+-- * Character set utf8
 --
+-- The following is an example on how you would use this function when inserting a car with the brand \"Volvo\" to the database.
 -- @
 -- saveCar = runDB $ insert $ Car \"Volvo\"
 -- @

--- a/src/Hastings/Database/Common.hs
+++ b/src/Hastings/Database/Common.hs
@@ -1,3 +1,4 @@
+-- | Contains database utility functions.
 module Hastings.Database.Common
    where
 

--- a/src/Hastings/Database/Common.hs
+++ b/src/Hastings/Database/Common.hs
@@ -12,13 +12,23 @@ import Hastings.Database.Fields
 migrateDatabase :: IO ()
 migrateDatabase = runDB $ Esql.runMigration migrateAll
 
+
+hastingsConnectionInfo = MySQL.defaultConnectInfo {
+  MySQL.connectHost = "localhost",
+  MySQL.connectPort = 3306,
+  MySQL.connectUser = "root",
+  MySQL.connectPassword = "",
+  MySQL.connectDatabase = "hastings"
+}
+
+
 -- |Helper function that should be called before running a query on the database.
 --  It's primary purpose is running the proper prerequisites to be able to excecute an SQL query on the database.
 --  It connects to a database with the following connection information
 -- * Server on localhost
 -- * User root
 -- * No password
--- * Database test
+-- * Database hastings
 -- * Character set utf8
 --
 -- The following is an example on how you would use this function when inserting a car with the brand \"Volvo\" to the database.
@@ -26,4 +36,4 @@ migrateDatabase = runDB $ Esql.runMigration migrateAll
 -- saveCar = runDB $ insert $ Car \"Volvo\"
 -- @
 runDB :: MySQL.SqlPersistT (Logger.NoLoggingT IO) a -> IO a
-runDB = Logger.runNoLoggingT . MySQL.withMySQLConn MySQL.defaultConnectInfo . Esql.runSqlConn
+runDB = Logger.runNoLoggingT . MySQL.withMySQLConn hastingsConnectionInfo . Esql.runSqlConn

--- a/src/Hastings/Database/Common.hs
+++ b/src/Hastings/Database/Common.hs
@@ -3,14 +3,14 @@ module Hastings.Database.Common
    where
 
 import qualified Database.Persist.MySQL as MySQL
-import Database.Esqueleto
-import Control.Monad.Logger
+import qualified Database.Esqueleto as Esql
+import qualified Control.Monad.Logger as Logger
 
 import Hastings.Database.Fields
 
 -- |Run database migration, creating all relevant tables.
 migrateDatabase :: IO ()
-migrateDatabase = runDB $ runMigration migrateAll
+migrateDatabase = runDB $ Esql.runMigration migrateAll
 
 -- |Helper function that should be called before running a query on the database.
 --  It's primary purpose is running the proper prerequisites to be able to excecute an SQL query on the database.
@@ -25,5 +25,5 @@ migrateDatabase = runDB $ runMigration migrateAll
 -- @
 -- saveCar = runDB $ insert $ Car \"Volvo\"
 -- @
-runDB :: SqlPersistT (NoLoggingT IO) a -> IO a
-runDB = runNoLoggingT . MySQL.withMySQLConn MySQL.defaultConnectInfo . runSqlConn
+runDB :: MySQL.SqlPersistT (Logger.NoLoggingT IO) a -> IO a
+runDB = Logger.runNoLoggingT . MySQL.withMySQLConn MySQL.defaultConnectInfo . Esql.runSqlConn

--- a/src/Hastings/Database/Fields.hs
+++ b/src/Hastings/Database/Fields.hs
@@ -12,6 +12,7 @@
 module Hastings.Database.Fields where
 
 import Database.Persist.TH
+import Data.Word (Word64)
 
 share [mkPersist sqlSettings, mkMigrate "migrateAll"] [persistLowerCase|
 Game
@@ -19,5 +20,5 @@ Game
     maxAmountOfPlayers Int
 Player
     userName String
-    session String
+    session Word64
 |]

--- a/src/Hastings/Database/Fields.hs
+++ b/src/Hastings/Database/Fields.hs
@@ -16,13 +16,13 @@ import Data.Word (Word64)
 
 share [mkPersist sqlSettings, mkMigrate "migrateAll"] [persistLowerCase|
 Game
-    name String
+    name               String
     maxAmountOfPlayers Int
 Player
-    userName String
+    userName       String
     UniqueUsername userName
 OnlinePlayer
-    player PlayerId
-    sessionID Word64
+    player        PlayerId
+    sessionID     Word64
     UniqueSession sessionID
 |]

--- a/src/Hastings/Database/Fields.hs
+++ b/src/Hastings/Database/Fields.hs
@@ -20,6 +20,9 @@ Game
     maxAmountOfPlayers Int
 Player
     userName String
-    session Word64
-    UniqueSession session
+    UniqueUsername userName
+OnlinePlayer
+    player PlayerId
+    sessionID Word64
+    UniqueSession sessionID
 |]

--- a/src/Hastings/Database/Fields.hs
+++ b/src/Hastings/Database/Fields.hs
@@ -21,4 +21,5 @@ Game
 Player
     userName String
     session Word64
+    UniqueSession session
 |]

--- a/src/Hastings/Database/Fields.hs
+++ b/src/Hastings/Database/Fields.hs
@@ -12,7 +12,7 @@
 module Hastings.Database.Fields where
 
 import Database.Persist.TH
-import Data.Word (Word64)
+import Haste.App (SessionID)
 
 share [mkPersist sqlSettings, mkMigrate "migrateAll"] [persistLowerCase|
 Game
@@ -23,6 +23,6 @@ Player
     UniqueUsername userName
 OnlinePlayer
     player        PlayerId
-    sessionID     Word64
+    sessionID     SessionID
     UniqueSession sessionID
 |]

--- a/src/Hastings/Database/Fields.hs
+++ b/src/Hastings/Database/Fields.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE EmptyDataDecls             #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE QuasiQuotes                #-}
+{-# LANGUAGE TemplateHaskell            #-}
+{-# LANGUAGE TypeFamilies               #-}
+-- | All database fields.
+
+module Hastings.Database.Fields where
+
+import Database.Persist.TH
+
+share [mkPersist sqlSettings, mkMigrate "migrateAll"] [persistLowerCase|
+Game
+    name String
+    maxAmountOfPlayers Int
+Player
+    userName String
+    session String
+|]

--- a/src/Hastings/Database/Player.hs
+++ b/src/Hastings/Database/Player.hs
@@ -15,10 +15,9 @@ savePlayer name sessionID = runDB $ insert $ Player name sessionID
 
 -- |Retrieve a player from the database.
 retrievePlayer :: Word64 -- ^The sessionID of the player to retrieve.
-               -> IO [Entity Player]
-retrievePlayer sessionID = runDB $
-  select $
-    from $ \p -> do
-      where_ (p ^. PlayerSession ==. val sessionID)
-      return p
-
+               -> IO (Maybe Player)
+retrievePlayer sessionID = runDB $ do
+  t <- getBy $ UniqueSession sessionID
+  case t of
+    Just entity -> return $ Just $ entityVal entity
+    _           -> return Nothing

--- a/src/Hastings/Database/Player.hs
+++ b/src/Hastings/Database/Player.hs
@@ -2,33 +2,33 @@
 module Hastings.Database.Player
    where
 
-import Hastings.Database.Common
+import Hastings.Database.Common (runDB)
 import Hastings.Database.Fields
 
-import Database.Esqueleto
+import qualified Database.Esqueleto as Esql
 import Data.Word (Word64)
 import Data.Maybe (listToMaybe)
 
 
 -- |Save a player to the database.
 savePlayer :: String -- ^The name of the player to save.
-           -> IO (Key Player)
-savePlayer name = runDB $ insert $ Player name
+           -> IO (Esql.Key Player)
+savePlayer name = runDB $ Esql.insert $ Player name
 
 -- |Delete a player from the database.
 deletePlayer :: String -- ^The username of the player to delete.
              -> IO ()
-deletePlayer userName = runDB $ deleteBy $ UniqueUsername userName
+deletePlayer userName = runDB $ Esql.deleteBy $ UniqueUsername userName
 
 -- |Retrieve a player from the database by their username.
 retrievePlayerbyUsername :: String -- ^The username of the player to retrieve.
-                         -> IO (Maybe (Entity Player))
-retrievePlayerbyUsername name = runDB $ getBy $ UniqueUsername name
+                         -> IO (Maybe (Esql.Entity Player))
+retrievePlayerbyUsername name = runDB $ Esql.getBy $ UniqueUsername name
 
 -- |Change the username of a player.
 changeUserName :: String -- ^The old username.
                -> String -- ^The new username.
-               -> IO (Key Player)
+               -> IO (Esql.Key Player)
 changeUserName oldName newName = do
   deletePlayer oldName
   savePlayer newName
@@ -37,15 +37,15 @@ changeUserName oldName newName = do
 --  Creates a new player with the specified username if the player doesn't exist.
 saveOnlinePlayer :: String -- ^The name of the player to save.
                  -> Word64 -- ^The sessionID of the player to save.
-                 -> IO (Key OnlinePlayer)
+                 -> IO (Esql.Key OnlinePlayer)
 saveOnlinePlayer name sessionID = do
   player <- retrievePlayerbyUsername name
   case player of
-    Just entity -> saveOnlinePlayer' sessionID (entityKey entity)
+    Just entity -> saveOnlinePlayer' sessionID (Esql.entityKey entity)
     _           -> savePlayer name >>= saveOnlinePlayer' sessionID
 
     where
-      saveOnlinePlayer' sessionID key = runDB $ insert $ OnlinePlayer key sessionID
+      saveOnlinePlayer' sessionID key = runDB $ Esql.insert $ OnlinePlayer key sessionID
 
 
 -- |Retrieve an online player from the database.
@@ -57,15 +57,15 @@ saveOnlinePlayer name sessionID = do
 -- WHERE OnlinePlayer.Player == Player.Id
 -- @
 retrieveOnlinePlayer :: Word64 -- ^The sessionID of the player to retrieve.
-                     -> IO (Maybe (Entity Player))
+                     -> IO (Maybe (Esql.Entity Player))
 retrieveOnlinePlayer sessionID = runDB $ do
-  playerList <- select $
-       from $ \(b, p) -> do
-         where_ (b ^. OnlinePlayerPlayer ==. p ^. PlayerId)
+  playerList <- Esql.select $
+       Esql.from $ \(b, p) -> do
+         Esql.where_ (b Esql.^. OnlinePlayerPlayer Esql.==. p Esql.^. PlayerId)
          return p
   return $ listToMaybe playerList
 
 -- |Delete an online player from the database.
 deleteOnlinePlayer :: Word64 -- ^The sessionID of the player to delete.
                    -> IO ()
-deleteOnlinePlayer sessionID = runDB $ deleteBy $ UniqueSession sessionID
+deleteOnlinePlayer sessionID = runDB $ Esql.deleteBy $ UniqueSession sessionID

--- a/src/Hastings/Database/Player.hs
+++ b/src/Hastings/Database/Player.hs
@@ -1,0 +1,23 @@
+module Hastings.Database.Player
+   where
+
+import Hastings.Database.Common
+import Hastings.Database.Fields
+
+import Database.Esqueleto
+
+-- |Save a game to the database.
+savePlayer :: String -- ^The name of the player to save.
+           -> String -- ^The sessionID of the player
+           -> IO (Key Player)
+savePlayer name sessionID = runDB $ insert $ Player name sessionID
+
+-- |Retrieve a game from the database.
+retrievePlayer :: String -- ^The sessionID of the player to retrieve.
+               -> IO [Entity Player]
+retrievePlayer sessionID = runDB $
+  select $
+    from $ \p -> do
+      where_ (p ^. PlayerSession ==. val sessionID)
+      return p
+

--- a/src/Hastings/Database/Player.hs
+++ b/src/Hastings/Database/Player.hs
@@ -8,7 +8,7 @@ import Hastings.Database.Fields
 import qualified Database.Esqueleto as Esql
 import qualified Database.Persist.Sql as Pers
 
-import Data.Word (Word64)
+import Haste.App (SessionID)
 import Data.Maybe (listToMaybe)
 
 
@@ -39,7 +39,7 @@ changeUserName oldName newName = runDB $ do
 -- |Save an new online player to the database.
 --  Creates a new player with the specified username if the player doesn't exist.
 saveOnlinePlayer :: String -- ^The name of the player to save.
-                 -> Word64 -- ^The sessionID of the player to save.
+                 -> SessionID -- ^The sessionID of the player to save.
                  -> IO (Esql.Key OnlinePlayer)
 saveOnlinePlayer name sessionID = do
   player <- retrievePlayerByUsername name
@@ -59,7 +59,7 @@ saveOnlinePlayer name sessionID = do
 -- SELECT OnlinePlayer.*, Player.*
 -- WHERE OnlinePlayer.Player == Player.Id && OnlinePlayer.sessionID == sessionID
 -- @
-retrieveOnlinePlayer :: Word64 -- ^The sessionID of the player to retrieve.
+retrieveOnlinePlayer :: SessionID -- ^The sessionID of the player to retrieve.
                      -> IO (Maybe (Esql.Entity Player))
 retrieveOnlinePlayer sessionID = runDB $ do
   playerList <- Esql.select $
@@ -70,7 +70,7 @@ retrieveOnlinePlayer sessionID = runDB $ do
   return $ listToMaybe playerList
 
 -- |Delete an online player from the database.
-deleteOnlinePlayer :: Word64 -- ^The sessionID of the player to delete.
+deleteOnlinePlayer :: SessionID -- ^The sessionID of the player to delete.
                    -> IO ()
 deleteOnlinePlayer sessionID = runDB $ Esql.deleteBy $ UniqueSession sessionID
 

--- a/src/Hastings/Database/Player.hs
+++ b/src/Hastings/Database/Player.hs
@@ -22,9 +22,9 @@ deletePlayer :: String -- ^The username of the player to delete.
 deletePlayer userName = runDB $ Esql.deleteBy $ UniqueUsername userName
 
 -- |Retrieve a player from the database by their username.
-retrievePlayerbyUsername :: String -- ^The username of the player to retrieve.
+retrievePlayerByUsername :: String -- ^The username of the player to retrieve.
                          -> IO (Maybe (Esql.Entity Player))
-retrievePlayerbyUsername name = runDB $ Esql.getBy $ UniqueUsername name
+retrievePlayerByUsername name = runDB $ Esql.getBy $ UniqueUsername name
 
 -- |Change the username of a player.
 changeUserName :: String -- ^The old username.
@@ -41,7 +41,7 @@ saveOnlinePlayer :: String -- ^The name of the player to save.
                  -> Word64 -- ^The sessionID of the player to save.
                  -> IO (Esql.Key OnlinePlayer)
 saveOnlinePlayer name sessionID = do
-  player <- retrievePlayerbyUsername name
+  player <- retrievePlayerByUsername name
   case player of
     Just entity -> saveOnlinePlayer' sessionID (Esql.entityKey entity)
     _           -> savePlayer name >>= saveOnlinePlayer' sessionID

--- a/src/Hastings/Database/Player.hs
+++ b/src/Hastings/Database/Player.hs
@@ -1,3 +1,4 @@
+-- | Contains database functions that manipulate 'OnlinePlayer' and 'Player'
 module Hastings.Database.Player
    where
 
@@ -46,7 +47,15 @@ saveOnlinePlayer name sessionID = do
     where
       saveOnlinePlayer' sessionID key = runDB $ insert $ OnlinePlayer key sessionID
 
+
 -- |Retrieve an online player from the database.
+--
+--  Runs this query on the database.
+--
+-- @
+-- SELECT OnlinePlayer.*, Player.Id
+-- WHERE OnlinePlayer.Player == Player.Id
+-- @
 retrieveOnlinePlayer :: Word64 -- ^The sessionID of the player to retrieve.
                      -> IO (Maybe (Entity Player))
 retrieveOnlinePlayer sessionID = runDB $ do

--- a/src/Hastings/Database/Player.hs
+++ b/src/Hastings/Database/Player.hs
@@ -6,6 +6,7 @@ import Hastings.Database.Common (runDB)
 import Hastings.Database.Fields
 
 import qualified Database.Esqueleto as Esql
+
 import Data.Word (Word64)
 import Data.Maybe (listToMaybe)
 
@@ -28,10 +29,11 @@ retrievePlayerbyUsername name = runDB $ Esql.getBy $ UniqueUsername name
 -- |Change the username of a player.
 changeUserName :: String -- ^The old username.
                -> String -- ^The new username.
-               -> IO (Esql.Key Player)
-changeUserName oldName newName = do
-  deletePlayer oldName
-  savePlayer newName
+               -> IO ()
+changeUserName oldName newName = runDB $ do
+  Esql.update $ \player -> do
+    Esql.set player [PlayerUserName Esql.=. Esql.val newName]
+    Esql.where_ (player Esql.^. PlayerUserName Esql.==. Esql.val oldName)
 
 -- |Save an new online player to the database.
 --  Creates a new player with the specified username if the player doesn't exist.

--- a/src/Hastings/Database/Player.hs
+++ b/src/Hastings/Database/Player.hs
@@ -24,6 +24,14 @@ retrievePlayerbyUsername :: String -- ^The username of the player to retrieve.
                          -> IO (Maybe (Entity Player))
 retrievePlayerbyUsername name = runDB $ getBy $ UniqueUsername name
 
+-- |Change the username of a player.
+changeUserName :: String -- ^The old username.
+               -> String -- ^The new username.
+               -> IO (Key Player)
+changeUserName oldName newName = do
+  deletePlayer oldName
+  savePlayer newName
+
 -- |Save an new online player to the database.
 --  Creates a new player with the specified username if the player doesn't exist.
 saveOnlinePlayer :: String -- ^The name of the player to save.

--- a/src/Hastings/Database/Player.hs
+++ b/src/Hastings/Database/Player.hs
@@ -43,3 +43,7 @@ retrieveOnlinePlayer sessionID = runDB $ do
          return p
   return $ listToMaybe playerList
 
+-- |Delete an online player from the database.
+deleteOnlinePlayer :: Word64 -- ^The sessionID of the player to delete.
+                   -> IO ()
+deleteOnlinePlayer sessionID = runDB $ deleteBy $ UniqueSession sessionID

--- a/src/Hastings/Database/Player.hs
+++ b/src/Hastings/Database/Player.hs
@@ -56,16 +56,17 @@ saveOnlinePlayer name sessionID = do
 --  Runs this query on the database.
 --
 -- @
--- SELECT OnlinePlayer.*, Player.Id
--- WHERE OnlinePlayer.Player == Player.Id
+-- SELECT OnlinePlayer.*, Player.*
+-- WHERE OnlinePlayer.Player == Player.Id && OnlinePlayer.sessionID == sessionID
 -- @
 retrieveOnlinePlayer :: Word64 -- ^The sessionID of the player to retrieve.
                      -> IO (Maybe (Esql.Entity Player))
 retrieveOnlinePlayer sessionID = runDB $ do
   playerList <- Esql.select $
-       Esql.from $ \(b, p) -> do
-         Esql.where_ (b Esql.^. OnlinePlayerPlayer Esql.==. p Esql.^. PlayerId)
-         return p
+       Esql.from $ \(onlinePlayers, players) -> do
+         Esql.where_ (onlinePlayers Esql.^. OnlinePlayerPlayer Esql.==. players Esql.^. PlayerId
+             Esql.&&. onlinePlayers Esql.^. OnlinePlayerSessionID Esql.==. Esql.val sessionID)
+         return players
   return $ listToMaybe playerList
 
 -- |Delete an online player from the database.

--- a/src/Hastings/Database/Player.hs
+++ b/src/Hastings/Database/Player.hs
@@ -14,6 +14,11 @@ savePlayer :: String -- ^The name of the player to save.
            -> IO (Key Player)
 savePlayer name = runDB $ insert $ Player name
 
+-- |Delete a player from the database.
+deletePlayer :: String -- ^The username of the player to delete.
+             -> IO ()
+deletePlayer userName = runDB $ deleteBy $ UniqueUsername userName
+
 -- |Retrieve a player from the database by their username.
 retrievePlayerbyUsername :: String -- ^The username of the player to retrieve.
                          -> IO (Maybe (Entity Player))

--- a/src/Hastings/Database/Player.hs
+++ b/src/Hastings/Database/Player.hs
@@ -6,6 +6,7 @@ import Hastings.Database.Common (runDB)
 import Hastings.Database.Fields
 
 import qualified Database.Esqueleto as Esql
+import qualified Database.Persist.Sql as Pers
 
 import Data.Word (Word64)
 import Data.Maybe (listToMaybe)
@@ -71,3 +72,7 @@ retrieveOnlinePlayer sessionID = runDB $ do
 deleteOnlinePlayer :: Word64 -- ^The sessionID of the player to delete.
                    -> IO ()
 deleteOnlinePlayer sessionID = runDB $ Esql.deleteBy $ UniqueSession sessionID
+
+-- |Delete all entries in the online players table
+clearOnlinePlayers :: IO ()
+clearOnlinePlayers = runDB $ Pers.deleteWhere ([] :: [Pers.Filter OnlinePlayer])

--- a/src/Hastings/Database/Player.hs
+++ b/src/Hastings/Database/Player.hs
@@ -6,18 +6,42 @@ import Hastings.Database.Fields
 
 import Database.Esqueleto
 import Data.Word (Word64)
+import Data.Maybe (listToMaybe)
+
 
 -- |Save a player to the database.
 savePlayer :: String -- ^The name of the player to save.
-           -> Word64 -- ^The sessionID of the player
            -> IO (Key Player)
-savePlayer name sessionID = runDB $ insert $ Player name sessionID
+savePlayer name = runDB $ insert $ Player name
 
--- |Retrieve a player from the database.
-retrievePlayer :: Word64 -- ^The sessionID of the player to retrieve.
-               -> IO (Maybe Player)
-retrievePlayer sessionID = runDB $ do
-  t <- getBy $ UniqueSession sessionID
-  case t of
-    Just entity -> return $ Just $ entityVal entity
-    _           -> return Nothing
+-- |Retrieve a player from the database by their username.
+retrievePlayerbyUsername :: String -- ^The username of the player to retrieve.
+                         -> IO (Maybe (Entity Player))
+retrievePlayerbyUsername name = runDB $ getBy $ UniqueUsername name
+
+-- |Save an an online player to the database.
+saveOnlinePlayer :: String -- ^The name of the player to save.
+                 -> Word64 -- ^The sessionID of the player to save.
+                 -> IO (Key OnlinePlayer)
+saveOnlinePlayer name sessionID = do
+  player <- retrievePlayerbyUsername name
+  case player of
+    Just entity -> saveOnlinePlayer' (entityKey entity) sessionID
+    _           -> do
+      key <- savePlayer name
+      saveOnlinePlayer' key sessionID
+
+    where
+      saveOnlinePlayer' key sessionID = runDB $ insert $ OnlinePlayer key sessionID
+
+
+-- |Retrieve an online player from the database.
+retrieveOnlinePlayer :: Word64 -- ^The sessionID of the player to retrieve.
+                     -> IO (Maybe (Entity Player))
+retrieveOnlinePlayer sessionID = runDB $ do
+  playerList <- select $
+       from $ \(b, p) -> do
+         where_ (b ^. OnlinePlayerPlayer ==. p ^. PlayerId)
+         return p
+  return $ listToMaybe playerList
+

--- a/src/Hastings/Database/Player.hs
+++ b/src/Hastings/Database/Player.hs
@@ -27,14 +27,11 @@ saveOnlinePlayer :: String -- ^The name of the player to save.
 saveOnlinePlayer name sessionID = do
   player <- retrievePlayerbyUsername name
   case player of
-    Just entity -> saveOnlinePlayer' (entityKey entity) sessionID
-    _           -> do
-      key <- savePlayer name
-      saveOnlinePlayer' key sessionID
+    Just entity -> saveOnlinePlayer' sessionID (entityKey entity)
+    _           -> savePlayer name >>= saveOnlinePlayer' sessionID
 
     where
-      saveOnlinePlayer' key sessionID = runDB $ insert $ OnlinePlayer key sessionID
-
+      saveOnlinePlayer' sessionID key = runDB $ insert $ OnlinePlayer key sessionID
 
 -- |Retrieve an online player from the database.
 retrieveOnlinePlayer :: Word64 -- ^The sessionID of the player to retrieve.

--- a/src/Hastings/Database/Player.hs
+++ b/src/Hastings/Database/Player.hs
@@ -31,7 +31,7 @@ retrievePlayerByUsername name = runDB $ Esql.getBy $ UniqueUsername name
 changeUserName :: String -- ^The old username.
                -> String -- ^The new username.
                -> IO ()
-changeUserName oldName newName = runDB $ do
+changeUserName oldName newName = runDB $
   Esql.update $ \player -> do
     Esql.set player [PlayerUserName Esql.=. Esql.val newName]
     Esql.where_ (player Esql.^. PlayerUserName Esql.==. Esql.val oldName)

--- a/src/Hastings/Database/Player.hs
+++ b/src/Hastings/Database/Player.hs
@@ -5,15 +5,16 @@ import Hastings.Database.Common
 import Hastings.Database.Fields
 
 import Database.Esqueleto
+import Data.Word (Word64)
 
--- |Save a game to the database.
+-- |Save a player to the database.
 savePlayer :: String -- ^The name of the player to save.
-           -> String -- ^The sessionID of the player
+           -> Word64 -- ^The sessionID of the player
            -> IO (Key Player)
 savePlayer name sessionID = runDB $ insert $ Player name sessionID
 
--- |Retrieve a game from the database.
-retrievePlayer :: String -- ^The sessionID of the player to retrieve.
+-- |Retrieve a player from the database.
+retrievePlayer :: Word64 -- ^The sessionID of the player to retrieve.
                -> IO [Entity Player]
 retrievePlayer sessionID = runDB $
   select $

--- a/src/Hastings/Database/Player.hs
+++ b/src/Hastings/Database/Player.hs
@@ -19,7 +19,8 @@ retrievePlayerbyUsername :: String -- ^The username of the player to retrieve.
                          -> IO (Maybe (Entity Player))
 retrievePlayerbyUsername name = runDB $ getBy $ UniqueUsername name
 
--- |Save an an online player to the database.
+-- |Save an new online player to the database.
+--  Creates a new player with the specified username if the player doesn't exist.
 saveOnlinePlayer :: String -- ^The name of the player to save.
                  -> Word64 -- ^The sessionID of the player to save.
                  -> IO (Key OnlinePlayer)

--- a/src/LobbyServer.hs
+++ b/src/LobbyServer.hs
@@ -47,7 +47,7 @@ import Hastings.ServerUtils
 #ifndef __HASTE__
 import Data.UUID
 import System.Random
-import Hastings.Database.Player
+import qualified Hastings.Database.Player as PlayerDB
 import qualified Hastings.Database.Fields as Fields
 import Database.Persist (entityKey, entityVal, Entity)
 #endif
@@ -66,7 +66,7 @@ connect remoteClientList remoteChats name = do
       lobbyChannel <- CC.newChan
       return $ ClientEntry sid name [] lobbyChannel : clients
 
-    liftIO $ saveOnlinePlayer name sid
+    liftIO $ PlayerDB.saveOnlinePlayer name sid
     clientList <- CC.readMVar concurrentClientList
     messageClients ClientJoined clientList
 
@@ -83,7 +83,7 @@ disconnect (clientList, games, chats) sid = do
 
   leaveGame games
   disconnectPlayerFromLobby clientList sid
-  liftIO $ deleteOnlinePlayer sid
+  liftIO $ PlayerDB.deleteOnlinePlayer sid
 
   mVarClients <- clientList
   liftIO $ do
@@ -229,8 +229,8 @@ changeNickName remoteClientList remoteGames newName = do
   mVarClientList <- remoteClientList
   clientList <- liftIO $ CC.readMVar mVarClientList
   sid <- getSessionID
-  player <- liftIO $ retrieveOnlinePlayer sid
-  liftIO $ changeUserName (oldName player) newName
+  player <- liftIO $ PlayerDB.retrieveOnlinePlayer sid
+  liftIO $ PlayerDB.changeUserName (oldName player) newName
 
   liftIO $ CC.modifyMVar_ mVarClientList $ \cs ->
     return $ updateNick sid cs

--- a/src/LobbyServer.hs
+++ b/src/LobbyServer.hs
@@ -63,6 +63,7 @@ connect remoteClientList remoteChats name = do
       lobbyChannel <- CC.newChan
       return $ ClientEntry sid name [] lobbyChannel : clients
 
+    liftIO $ saveOnlinePlayer name sid
     clientList <- CC.readMVar concurrentClientList
     messageClients ClientJoined clientList
 
@@ -79,6 +80,7 @@ disconnect (clientList, games, chats) sid = do
 
   leaveGame games
   disconnectPlayerFromLobby clientList sid
+  liftIO $ deleteOnlinePlayer sid
 
   mVarClients <- clientList
   liftIO $ do

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,11 +7,12 @@ packages:
     commit: bbd2641
 system-ghc: true
 extra-deps:
-- tar-0.5.0.1
 - HTTP-4000.2.23
 - cereal-0.4.1.1
-- shellmate-0.2.3
-- ghc-simple-0.3
 - data-embed-0.1.0.0
+- ghc-simple-0.3
 - haste-compiler-0.5.4
+- shellmate-0.2.3
+- tar-0.5.0.1
+- text-1.2.2.0
 resolver: lts-5.2


### PR DESCRIPTION
A barebones implementation of persistent storage using Persistent and Esqueleto.
Currently implements a player field and an onlineplayer field.
A player is added to the table OnlinePlayer when they join and removed when they leave, the username is also updated in the DB when the player changes its username.

Resolves #47  
